### PR TITLE
feat: unresolvable imports

### DIFF
--- a/packages/core/src/lib/eslint/deep-import.spec.ts
+++ b/packages/core/src/lib/eslint/deep-import.spec.ts
@@ -21,7 +21,11 @@ describe('deep import', () => {
         getFs().readFile(toFsPath(filename))
       ),
       `deep import in ${filename} from ${importCommand} should be ${isDeepImport}`
-    ).toBe(isDeepImport);
+    ).toBe(
+      isDeepImport
+        ? "Deep import is not allowed. Use the module's index.ts or path."
+        : ''
+    );
   };
 
   beforeAll(() => {
@@ -54,6 +58,25 @@ describe('deep import', () => {
       '/project/src/app/app.component.ts',
       './customers/customer.component'
     );
+  });
+
+  it('should mark an unresolvable import', () => {
+    const fileTree: FileTree = {
+      'tsconfig.json': tsconfigMinimal,
+      src: {
+        'main.ts': ['./app/app.component'],
+      },
+    };
+    new ProjectCreator().create(fileTree, '/project');
+
+    expect(
+      hasDeepImport(
+        '/project/src/main.ts',
+        './app/app.component',
+        true,
+        getFs().readFile(toFsPath('/project/src/main.ts'))
+      )
+    ).toBe('import ./app/app.component cannot be resolved');
   });
 
   describe('rootExcluded', () => {

--- a/packages/core/src/lib/eslint/violates-dependency-rule.spec.ts
+++ b/packages/core/src/lib/eslint/violates-dependency-rule.spec.ts
@@ -1,6 +1,60 @@
-import { describe, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vitest } from 'vitest';
+import * as generator from '../file-info/generate-file-info';
+import { FileTree, sheriffConfig } from '../test/project-configurator';
+import tsconfigMinimal from '../test/fixtures/tsconfig.minimal';
+import { ProjectCreator } from '../test/project-creator';
+import getFs, { useVirtualFs } from '../fs/getFs';
+import { toFsPath } from '../file-info/fs-path';
+import { violatesDependencyRule } from './violates-dependency-rule';
 
 describe('violates dependency rules', () => {
-  it.todo('should only run once');
-  it.todo('should only run once if there is no config file available');
+  beforeAll(() => {
+    useVirtualFs();
+  });
+
+  beforeEach(() => {
+    getFs().reset();
+  });
+
+  it('should not generate fileInfo when no config file available', () => {
+    const spy = vitest.spyOn(generator, 'generateFileInfo');
+
+    const fileTree: FileTree = {
+      'tsconfig.json': tsconfigMinimal,
+      src: {
+        'main.ts': [''],
+      },
+    };
+    new ProjectCreator().create(fileTree, '/project');
+
+    expect(
+      violatesDependencyRule(
+        '/project/src/main.ts',
+        './app/app.component',
+        true,
+        getFs().readFile(toFsPath('/project/src/main.ts'))
+      )
+    ).toBe('');
+    expect(spy).not.toBeCalled();
+  });
+
+  it('should show a unresolvable import', () => {
+    const fileTree: FileTree = {
+      'tsconfig.json': tsconfigMinimal,
+      'sheriff.config.ts': sheriffConfig({ tagging: {}, depRules: {} }),
+      src: {
+        'main.ts': ['./app.component'],
+      },
+    };
+    new ProjectCreator().create(fileTree, '/project');
+
+    expect(
+      violatesDependencyRule(
+        '/project/src/main.ts',
+        './app.component',
+        true,
+        getFs().readFile(toFsPath('/project/src/main.ts'))
+      )
+    ).toBe('import ./app.component cannot be resolved');
+  });
 });

--- a/packages/core/src/lib/file-info/file-info.ts
+++ b/packages/core/src/lib/file-info/file-info.ts
@@ -2,9 +2,30 @@ import { FsPath, toFsPath } from './fs-path';
 import throwIfNull from '../util/throw-if-null';
 import getFs from '../fs/getFs';
 
+/**
+ * Class representing a TypeScript file with its dependencies.
+ * If an import cannot be resolved, it doesn't throw an error
+ * but is added to unresolvableImports.
+ *
+ * It is up to the consumer, e.g. ESLinter, to decide if that
+ * should cause an error or not.
+ */
 export default class FileInfo {
   #rawImportMap = new Map<string, string>();
+  #unresolvableImports: string[] = [];
   constructor(public path: FsPath, public imports: FileInfo[] = []) {}
+
+  addUnresolvableImport(importCommand: string) {
+    this.#unresolvableImports.push(importCommand);
+  }
+
+  isUnresolvableImport(importCommand: string) {
+    return this.#unresolvableImports.includes(importCommand);
+  }
+
+  hasUnresolvableImports() {
+    return this.#unresolvableImports.length > 0;
+  }
 
   addImport(importedFileInfo: FileInfo, rawImport: string) {
     this.imports.push(importedFileInfo);

--- a/packages/core/src/lib/file-info/generate-file-info.spec.ts
+++ b/packages/core/src/lib/file-info/generate-file-info.spec.ts
@@ -142,4 +142,26 @@ describe('Generate File Info', () => {
       '/project/outside.component.ts is outside of root /project/integration'
     );
   });
+
+  for (const importCommand of [
+    './holiday.component',
+    './customers/customer.service',
+  ]) {
+    it(`should add an unresolvable import for "${importCommand}"`, () => {
+      const projectConfig: FileTree = {
+        'tsconfig.json': tsconfigMinimal,
+        'main.ts': [importCommand],
+      };
+
+      creator.create(projectConfig, 'integration');
+      const fileInfo = generateFileInfo(
+        toFsPath('/project/integration/main.ts'),
+        true,
+        getTsData()
+      );
+
+      expect(fileInfo.isUnresolvableImport(importCommand)).toBe(true);
+      expect(fileInfo.hasUnresolvableImports()).toBe(true);
+    });
+  }
 });

--- a/packages/core/src/lib/file-info/traverse-filesystem.ts
+++ b/packages/core/src/lib/file-info/traverse-filesystem.ts
@@ -59,7 +59,9 @@ const traverseFilesystem = (
       }
     } else if (fileName.startsWith('.')) {
       // might be an undetected dependency in node_modules
-      throw new Error(`cannot find import for ${fileName}`);
+      // or an incomplete import (= developer is still typing),
+      // if we read from an unsaved file via ESLint.
+      fileInfo.addUnresolvableImport(fileName);
     } else {
       const resolvedTsPath = resolvePotentialTsPath(
         fileName,

--- a/packages/eslint-plugin/src/lib/rules/deep-import.spec.ts
+++ b/packages/eslint-plugin/src/lib/rules/deep-import.spec.ts
@@ -29,7 +29,7 @@ describe('deep-import', () => {
       moduleName: '@angular/core',
     },
   ])('should check for $moduleName in $code', ({ code, moduleName }) => {
-    spy.mockImplementation(() => false);
+    spy.mockImplementation(() => '');
     tester.run('deep-import', deepImport, {
       valid: [{ code }],
       invalid: [],
@@ -45,8 +45,8 @@ describe('deep-import', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('should report error when deepImports returns false', () => {
-    spy.mockImplementation(() => true);
+  it('should use any message from deep import', () => {
+    spy.mockImplementation(() => 'nothing works');
     tester.run('deep-import', deepImport, {
       valid: [],
       invalid: [
@@ -54,8 +54,7 @@ describe('deep-import', () => {
           code: 'import {AppComponent} from "./app.component"',
           errors: [
             {
-              message:
-                "Deep import is not allowed. Use the module's index.ts or path.",
+              message: 'nothing works',
             },
           ],
         },

--- a/packages/eslint-plugin/src/lib/rules/deep-import.ts
+++ b/packages/eslint-plugin/src/lib/rules/deep-import.ts
@@ -14,10 +14,15 @@ export const deepImport = createRule(
   ) => {
     // ESTree does not have source on `ImportExpression`.
     const importValue = (node.source as { value: string }).value;
-    if (hasDeepImport(filename, importValue, isFirstRun, sourceCode)) {
+    const message = hasDeepImport(
+      filename,
+      importValue,
+      isFirstRun,
+      sourceCode
+    );
+    if (message) {
       context.report({
-        message:
-          "Deep import is not allowed. Use the module's index.ts or path.",
+        message,
         node,
       });
     }

--- a/test-projects/angular-iii/src/app/customers/feature/components/customers-container.component.ts
+++ b/test-projects/angular-iii/src/app/customers/feature/components/customers-container.component.ts
@@ -1,7 +1,7 @@
 import { AsyncPipe, NgIf } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { CustomersComponent, CustomersViewModel } from '@eternal/customers/ui';
-import { CustomersRepository } from '../../data/customers-repository.servic';
+import { CustomersRepository } from '../../data';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 

--- a/test-projects/angular-iii/src/app/customers/feature/components/customers-container.component.ts
+++ b/test-projects/angular-iii/src/app/customers/feature/components/customers-container.component.ts
@@ -1,7 +1,7 @@
 import { AsyncPipe, NgIf } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { CustomersComponent, CustomersViewModel } from '@eternal/customers/ui';
-import { CustomersRepository } from '../../data';
+import { CustomersRepository } from '../../data/customers-repository.servic';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 


### PR DESCRIPTION
unresolvable imports will not crash the FileInfo build-up.

Instead, an unresolvable import is stored and the ESLint rules
show it as an error.