### PR TITLE
fix(core): disable ts importHelpers

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "target": "es2015",
     "module": "esnext",
     "lib": ["es2017", "dom"],


### PR DESCRIPTION
Set property `importHelpers` in `tsconfig.base.json` to false. This removes `tslib` as a dependency, leaving
core's single dependency to be `typescript`.