### PR TITLE
fix: file extension in path mapping

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softarc/sheriff-core",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "homepage": "https://github.com/softarc-consulting/sheriff",
   "author": {
     "name": "Rainer Hahnekamp",

--- a/packages/core/src/lib/file-info/get-ts-paths-and-root-dir.spec.ts
+++ b/packages/core/src/lib/file-info/get-ts-paths-and-root-dir.spec.ts
@@ -1,6 +1,133 @@
-import { it, describe } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import getFs, { useVirtualFs } from '../fs/getFs';
+import { Fs } from '../fs/fs';
+import { tsConfigMinimal } from '../test/fixtures/tsconfig.minimal';
+import { ProjectCreator } from '../test/project-creator';
+import { toFsPath } from './fs-path';
+import { TsConfig } from './ts-config';
+import { getTsPathsAndRootDir } from './get-ts-paths-and-root-dir';
 
 describe('get ts paths and root dir', () => {
-  it.todo('ensure that paths work with relative path');
-  it.todo('should throw an error if a path does not exist');
+  let fs: Fs;
+
+  beforeAll(() => {
+    useVirtualFs();
+  });
+
+  beforeEach(() => {
+    fs = getFs();
+    fs.reset();
+  });
+
+  for (const { name, tsPaths, fsPaths } of [
+    {
+      name: 'default paths',
+      tsPaths: {
+        '@app/*': ['src/app'],
+        '@customers': ['src/app/customers/index.ts'],
+        '@holidays': ['src/app/holidays/index.ts'],
+      },
+      fsPaths: {
+        '@app/*': '/project/src/app',
+        '@customers': '/project/src/app/customers/index.ts',
+        '@holidays': '/project/src/app/holidays/index.ts',
+      },
+    },
+    {
+      name: 'directory path',
+      tsPaths: {
+        '@customers': ['src/app/customers'],
+      },
+      fsPaths: {
+        '@customers': '/project/src/app/customers',
+      },
+    },
+    {
+      name: 'file without extension path',
+      tsPaths: {
+        '@customers': ['src/app/customers/index'],
+      },
+      fsPaths: {
+        '@customers': '/project/src/app/customers/index.ts',
+      },
+    },
+  ]) {
+    test(name, () => {
+      const tsConfig = structuredClone(tsConfigMinimal) as TsConfig;
+      tsConfig.compilerOptions.paths = tsPaths;
+      new ProjectCreator().create(
+        {
+          'tsconfig.json': JSON.stringify(tsConfig),
+          src: {
+            app: {
+              'main.ts': [],
+              customers: {
+                'index.ts': [],
+              },
+              holidays: {
+                'index.ts': [],
+              },
+            },
+          },
+        },
+        '/project'
+      );
+
+      expect(
+        getTsPathsAndRootDir(toFsPath('/project/tsconfig.json')).paths
+      ).toEqual(fsPaths);
+    });
+  }
+
+  for (const { name, tsPaths, errorMessage } of [
+    {
+      name: 'not existing path',
+      tsPaths: {
+        '@app': ['src/app/sdf'],
+      },
+      errorMessage: '@app: src/app/sdf',
+    },
+    {
+      name: 'not existing file',
+      tsPaths: {
+        '@main': ['src/app/index'],
+      },
+      errorMessage: '@main: src/app/index',
+    },
+    {
+      name: 'not existing path with wildcard',
+      tsPaths: {
+        '@app/*': ['src/app/somewhere'],
+      },
+      errorMessage: '@app/*: src/app/somewhere',
+    },
+  ]) {
+    test(name, () => {
+      const tsConfig = structuredClone(tsConfigMinimal) as TsConfig;
+      tsConfig.compilerOptions.paths = tsPaths;
+      new ProjectCreator().create(
+        {
+          'tsconfig.json': JSON.stringify(tsConfig),
+          src: {
+            app: {
+              'main.ts': [],
+              customers: {
+                'index.ts': [],
+              },
+              holidays: {
+                'index.ts': [],
+              },
+            },
+          },
+        },
+        '/project'
+      );
+
+      expect(() =>
+        getTsPathsAndRootDir(toFsPath('/project/tsconfig.json'))
+      ).toThrowError(
+        `invalid path mapping detected: ${errorMessage}. Please verify that the path exists.`
+      );
+    });
+  }
 });

--- a/packages/core/src/lib/file-info/get-ts-paths-and-root-dir.ts
+++ b/packages/core/src/lib/file-info/get-ts-paths-and-root-dir.ts
@@ -34,7 +34,19 @@ export const getTsPathsAndRootDir = (
     currentTsConfigDir = fs.getParent(currentTsConfigPath);
     for (const [key, [value]] of Object.entries(newPaths)) {
       const valueForFsPath = value.endsWith('/*') ? value.slice(0, -2) : value;
-      paths[key] = toFsPath(fs.join(currentTsConfigDir, valueForFsPath));
+      const potentialFilename = fs.join(currentTsConfigDir, valueForFsPath);
+      if (fs.exists(potentialFilename)) {
+        paths[key] = toFsPath(potentialFilename);
+      } else if (
+        !potentialFilename.endsWith('.ts') &&
+        fs.exists(potentialFilename + '.ts')
+      ) {
+        paths[key] = toFsPath(potentialFilename + '.ts');
+      } else {
+        throw new Error(
+          `invalid path mapping detected: ${key}: ${value}. Please verify that the path exists.`
+        );
+      }
     }
 
     if (config.extends) {

--- a/packages/core/src/lib/file-info/traverse-filesystem.spec.ts
+++ b/packages/core/src/lib/file-info/traverse-filesystem.spec.ts
@@ -126,6 +126,32 @@ describe('traverse file-system', () => {
     );
   });
 
+  it('should automatically pick the file extension if missing in path', () => {
+    const tsConfig = structuredClone(tsConfigMinimal) as TsConfig;
+    tsConfig.compilerOptions.paths = {
+      '@customers': ['/src/app/customers/index'],
+    };
+    const { tsData, mainPath } = createProject({
+      'tsconfig.json': JSON.stringify(tsConfig),
+      src: {
+        'main.ts': ['./app/app.component'],
+        app: {
+          'app.component.ts': ['@customers'],
+          customers: {
+            'index.ts': [],
+          },
+        },
+      },
+    });
+    const fileInfo = traverseFilesystem(mainPath, fileInfoDict, tsData);
+
+    expect(fileInfo).toEqual(
+      buildFileInfo('/project/src/main.ts', [
+        ['./app/app.component.ts', ['./customers/index.ts']],
+      ])
+    );
+  });
+
   it('should ignore an import if a non-wildcard path is used like a wildcard', () => {
     const tsConfig = structuredClone(tsConfigMinimal) as TsConfig;
     tsConfig.compilerOptions.paths = { '@customers': ['/src/app/customers'] };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@softarc/eslint-plugin-sheriff",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "homepage": "https://github.com/softarc-consulting/sheriff",
   "author": {
     "name": "Rainer Hahnekamp",
@@ -14,7 +14,7 @@
   "type": "commonjs",
   "dependencies": {},
   "peerDependencies": {
-    "@softarc/sheriff-core": "0.14.2",
+    "@softarc/sheriff-core": "0.14.3",
     "eslint": ">=8.0.0"
   }
 }

--- a/test-projects/angular-i/integration-test.sh
+++ b/test-projects/angular-i/integration-test.sh
@@ -5,26 +5,26 @@ yarn
 echo 'checking for dynamic import error'
 cp ./tests/dynamic-import-sheriff.config.ts sheriff.config.ts
 npx ng lint --force --format json --output-file dynamic-import-lint.json
-npx ts-node --esm ../verify-linter.mts ./angular-i/tests/expected-dynamic-import-lint.json ./angular-i/dynamic-import-lint.json
+node ../verify-linter.mjs ./angular-i/tests/expected-dynamic-import-lint.json ./angular-i/dynamic-import-lint.json
 git checkout sheriff.config.ts
 
 ## Deep Import Check
 echo 'checking for deep import error'
 cp ./tests/customers-container.deep-import.component.ts src/app/customers/feature/components/customers-container.component.ts
 npx ng lint --force --format json --output-file deep-import-lint.json
-npx ts-node --esm ../verify-linter.mts ./angular-i/tests/expected-deep-import-lint.json ./angular-i/deep-import-lint.json
+node ../verify-linter.mjs ./angular-i/tests/expected-deep-import-lint.json ./angular-i/deep-import-lint.json
 git checkout src/app/customers/feature/components/customers-container.component.ts
 
 ## Dependency Rule Check
 echo 'checking for dependency rule error'
 cp ./tests/customer.dependency-rule.component.ts src/app/customers/ui/customer/customer.component.ts
 npx ng lint --force --format json --output-file dependency-rule-lint.json
-npx ts-node --esm ../verify-linter.mts ./angular-i/tests/expected-dependency-rule-lint.json ./angular-i/dependency-rule-lint.json
+node ../verify-linter.mjs ./angular-i/tests/expected-dependency-rule-lint.json ./angular-i/dependency-rule-lint.json
 git checkout src/app/customers/ui/customer/customer.component.ts
 
 ## Internal Error Processing
 echo 'checking for internal error processing'
 cp ./tests/empty-sheriff.config.ts ./sheriff.config.ts
 npx ng lint --force --format json --output-file internal-error-processing-lint.json
-npx ts-node --esm ../verify-linter.mts ./angular-i/tests/expected-internal-error-processing-lint.json ./angular-i/internal-error-processing-lint.json "$(pwd)"
+node ../verify-linter.mjs ./angular-i/tests/expected-internal-error-processing-lint.json ./angular-i/internal-error-processing-lint.json "$(pwd)"
 git checkout sheriff.config.ts

--- a/test-projects/typescript-i/integration-test.sh
+++ b/test-projects/typescript-i/integration-test.sh
@@ -6,7 +6,7 @@
 
 echo 'checking against different TypeScript versions'
 
-declare -a versions=('4.8' '4.9' '5.0' '5.1')
+declare -a versions=('4.8' '4.9' '5.0' '5.1' '5.2' '5.3')
 
 for version in ${versions[*]}; do
   npm install typescript@$version
@@ -20,5 +20,5 @@ for version in ${versions[*]}; do
   fi
 
   npx eslint src --format json --output-file lint.json
-  npx ts-node --esm ../verify-linter.mts ./typescript-i/tests/expected-lint.json ./typescript-i/lint.json
+  node ../verify-linter.mjs ./typescript-i/tests/expected-lint.json ./typescript-i/lint.json
 done

--- a/test-projects/verify-linter.mjs
+++ b/test-projects/verify-linter.mjs
@@ -11,14 +11,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Remove absolute filepaths
-function readLintWithClearedFilePaths(file: string) {
+function readLintWithClearedFilePaths(file) {
   let content = fs.readFileSync(file, {
     encoding: "utf-8"
   });
   if (projectPath) {
    content = content.replaceAll(projectPath, 'PROJECT_DIR')
   }
-  const linterErrors: [{ filePath: string }] = JSON.parse(content);
+  const linterErrors = JSON.parse(content);
 
   return JSON.stringify(
     linterErrors.map((linterError) => {


### PR DESCRIPTION
`tsconfig.json` path mappings which skipped the `.ts` extension are detected.

before a `{"customers": "src/customers/index"}` caused an error.