### PR TITLE
Reset color if no issues are found

### DIFF
--- a/packages/core/src/lib/cli/tests/__snapshots__/verify.spec.ts.snap
+++ b/packages/core/src/lib/cli/tests/__snapshots__/verify.spec.ts.snap
@@ -43,5 +43,5 @@ exports[`verify > should find no errors > log 1`] = `
 "
 <b>Verification Report</b>
 
-[32mNo issues found. Well done!"
+[32mNo issues found. Well done![0m"
 `;

--- a/packages/core/src/lib/cli/verify.ts
+++ b/packages/core/src/lib/cli/verify.ts
@@ -57,7 +57,7 @@ export function verify(args: string[]) {
     cli.log('');
   } else {
     cli.log('');
-    cli.log('\u001b[32mNo issues found. Well done!');
+    cli.log('\u001b[32mNo issues found. Well done!\u001b[0m');
     cli.endProcessOk();
   }
 

--- a/test-projects/angular-i/tests/expected-cli-verify.txt
+++ b/test-projects/angular-i/tests/expected-cli-verify.txt
@@ -1,4 +1,4 @@
 
 [1mVerification Report[0m
 
-[32mNo issues found. Well done![0m"
+[32mNo issues found. Well done![0m

--- a/test-projects/angular-i/tests/expected-cli-verify.txt
+++ b/test-projects/angular-i/tests/expected-cli-verify.txt
@@ -1,4 +1,4 @@
 
 [1mVerification Report[0m
 
-[32mNo issues found. Well done!
+[32mNo issues found. Well done![0m"


### PR DESCRIPTION
Thanks for creating and expanding Sheriff, I really like the library. As I am currently only using Sheriff via the CLI, I have noticed a bug. The green colour is not reset in the terminal and it looks a bit messy (on Windows):

![image](https://github.com/softarc-consulting/sheriff/assets/12248527/6a6149e5-d9b3-462e-9a46-b10476b94ac6)

This PR should resolve this issue by resetting the color at the end.