### PR TITLE
ci: run sheriff.full-spec.ts only in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn
       - run: yarn lint:all
       - run: yarn link:sheriff
-      - run: yarn test:coverage
+      - run: yarn test:ci
       - run: cd test-projects/angular-i && yarn && npx ng lint
       - run: cd test-projects/angular-ii && yarn && npx ng lint
       - run: cd test-projects/angular-iii && yarn && npx ng lint

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "link:sheriff": "npm run build:all && npm link dist/packages/core && npm link dist/packages/eslint-plugin",
     "run:cli": "nx build core && chmod +x dist/packages/core/src/bin/main.js",
     "test": "vitest",
-    "test:coverage": "vitest --coverage"
+    "test:ci": "vitest -c vitest.config.ci.ts"
   },
   "author": {
     "name": "Rainer Hahnekamp",

--- a/packages/core/src/sheriff.full-spec.ts
+++ b/packages/core/src/sheriff.full-spec.ts
@@ -13,7 +13,7 @@ describe('integration test', () => {
     it(`should test ${project}`, () => {
       const angularMain1 = path.join(
         __dirname,
-        '../../../..',
+        '../../..',
         'test-projects/',
         project,
         'src/main.ts',

--- a/packages/core/src/sheriff.full-spec.ts
+++ b/packages/core/src/sheriff.full-spec.ts
@@ -13,7 +13,7 @@ describe('integration test', () => {
     it(`should test ${project}`, () => {
       const angularMain1 = path.join(
         __dirname,
-        '../../../../..',
+        '../../../..',
         'test-projects/',
         project,
         'src/main.ts',

--- a/packages/core/src/sheriff.full-spec.ts
+++ b/packages/core/src/sheriff.full-spec.ts
@@ -1,8 +1,12 @@
+/**
+ * This test is excluded by default and only runs in the CI.
+ * This is because, it requires teh built packages
+ **/
 import { describe, it } from 'vitest';
 import * as path from 'path';
-import { generateUnassignedFileInfo } from './generate-unassigned-file-info';
-import { toFsPath } from './fs-path';
-import { init } from '../main/init';
+import { generateUnassignedFileInfo } from './lib/file-info/generate-unassigned-file-info';
+import { init } from './lib/main/init';
+import { toFsPath } from './lib/file-info/fs-path';
 
 describe('integration test', () => {
   for (const project of ['angular-i', 'angular-ii']) {

--- a/vitest.config.ci.ts
+++ b/vitest.config.ci.ts
@@ -1,0 +1,14 @@
+import { defaultConfig } from './vitest.config';
+import { defineConfig, UserConfigExport } from 'vitest/config';
+import { InlineConfig } from 'vitest';
+
+const config: UserConfigExport = {
+  ...defaultConfig,
+  test: {
+    ...defaultConfig.test,
+    include: ['packages/**/*.spec.ts', 'packages/**/*.full-spec.ts'],
+    coverage: { enabled: true },
+  },
+};
+
+export default defineConfig(config);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,12 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, UserConfigExport } from "vitest/config";
 
-export default defineConfig({
+export const defaultConfig = {
   test: {
     coverage: {
       provider: 'c8',
       reporter: ['text', 'html'],
     },
-    exclude: ['test-projects', 'docs', 'node_modules'],
+    include: ['packages/**/*.spec.ts']
   },
   resolve: {
     alias: {
@@ -14,4 +14,6 @@ export default defineConfig({
       '@softarc/sheriff-core': 'packages/core/src/index.ts',
     },
   },
-});
+} satisfies UserConfigExport;
+
+export default defineConfig(defaultConfig);


### PR DESCRIPTION
This particular test required
that all packages have been
built.

Since the pre-push commit should
run as fast as possible,
the full-spec test is not excluded
and only runs in the CI
automatically.