### PR TITLE
fix(eslint): remove parser from eslint plugin

### DIFF
--- a/packages/eslint-plugin/src/lib/configs/all.ts
+++ b/packages/eslint-plugin/src/lib/configs/all.ts
@@ -1,10 +1,8 @@
 import rules from '../rules';
-import { parser } from 'typescript-eslint';
 import type { TSESLint } from '@typescript-eslint/utils';
 
 export const all: TSESLint.FlatConfig.Config = {
   languageOptions: {
-    parser,
     sourceType: 'module',
   },
   plugins: {


### PR DESCRIPTION
Fixes: #114 

The parser is not necessary in a plugin, since
users should use a valid ESLint config which
already contains the parser.

Source: https://github.com/typescript-eslint/typescript-eslint/issues/9814#issuecomment-2294946153