### PR TITLE
feat(core): rename config property `tagging` to `modules`

### DIFF
--- a/packages/core/src/lib/api/get-project-data.ts
+++ b/packages/core/src/lib/api/get-project-data.ts
@@ -35,7 +35,7 @@ function calcOrGetTags(
   const tags = calcTagsForModule(
     modulePath,
     projectInfo.rootDir,
-    projectInfo.config.tagging,
+    projectInfo.config.modules,
     projectInfo.config.autoTagging,
   );
 

--- a/packages/core/src/lib/checks/check-for-deep-imports.ts
+++ b/packages/core/src/lib/checks/check-for-deep-imports.ts
@@ -1,5 +1,5 @@
 import { FsPath } from '../file-info/fs-path';
-import { SheriffConfig } from '../config/sheriff-config';
+import { Configuration } from '../config/configuration';
 import { ProjectInfo } from '../main/init';
 import { FileInfo } from '../modules/file.info';
 
@@ -62,7 +62,7 @@ function accessesBarrelFileForBarrelModules(fileInfo: FileInfo) {
 
 function isExcludedRootModule(
   rootDir: FsPath,
-  config: SheriffConfig,
+  config: Configuration,
   importedModule: FileInfo,
 ) {
   if (importedModule.moduleInfo.path !== rootDir) {

--- a/packages/core/src/lib/checks/check-for-dependency-rule-violation.ts
+++ b/packages/core/src/lib/checks/check-for-dependency-rule-violation.ts
@@ -36,7 +36,7 @@ export function checkForDependencyRuleViolation(
   const fromTags = calcTagsForModule(
     fromModule,
     rootDir,
-    config.tagging,
+    config.modules,
     config.autoTagging,
   );
 
@@ -48,7 +48,7 @@ export function checkForDependencyRuleViolation(
       const toTags: string[] = calcTagsForModule(
         toFsPath(importedModulePath),
         rootDir,
-        config.tagging,
+        config.modules,
         config.autoTagging,
       );
       const isViolation = !isDependencyAllowed(

--- a/packages/core/src/lib/checks/tests/check-for-deep-imports.barrel-less.spec.ts
+++ b/packages/core/src/lib/checks/tests/check-for-deep-imports.barrel-less.spec.ts
@@ -136,7 +136,7 @@ function assertProject(config: Partial<UserSheriffConfig> = {}) {
             'tsconfig.json': tsConfig(),
             'sheriff.config.ts': sheriffConfig({
               ...{
-                tagging: {
+                modules: {
                   'src/app/<domain>/<type>': ['domain:<domain>', 'type:<type>'],
                 },
                 depRules: {},

--- a/packages/core/src/lib/checks/tests/check-for-dependency-rule-violation.spec.ts
+++ b/packages/core/src/lib/checks/tests/check-for-dependency-rule-violation.spec.ts
@@ -57,7 +57,7 @@ describe('check for dependency rule violation', () => {
     const projectTemplate = () => ({
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/<domain>/feat-<type>': ['domain:<domain>', 'type:feature'],
           'src/<domain>/<type>': ['domain:<domain>', 'type:<type>'],
         },
@@ -248,7 +248,7 @@ describe('check for dependency rule violation', () => {
     const project = {
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/shared/<type>': ['shared'],
           'src/<domain>/<type>': ['domain:<domain>', 'type:<type>'],
         },
@@ -415,7 +415,7 @@ describe('check for dependency rule violation', () => {
       const projectInfo = testInit('src/app.component.ts', {
         'tsconfig.json': tsConfig(),
         'sheriff.config.ts': sheriffConfig({
-          tagging: {
+          modules: {
             'src/customers/<type>': ['domain:customers', 'type:<type>'],
           },
           depRules: {
@@ -485,7 +485,7 @@ describe('check for dependency rule violation', () => {
         },
       }),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/customers': ['domain:customers', 'type:feature'],
         },
         depRules: {
@@ -515,7 +515,7 @@ describe('check for dependency rule violation', () => {
     const projectInfo = testInit('src/customers/index.ts', {
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/customers': ['domain:customers', 'type:domain'],
           'src/customers/feature': ['domain:customers', 'type:feature'],
         },
@@ -555,7 +555,7 @@ describe('check for dependency rule violation', () => {
       return testInit('src/main.ts', {
         'tsconfig.json': tsConfig(),
         'sheriff.config.ts': sheriffConfig({
-          tagging: {
+          modules: {
             'src/customers': ['domain:customers', 'type:domain'],
             'src/customers/<type>': ['domain:customers', 'type:<type>'],
           },

--- a/packages/core/src/lib/checks/tests/deep-import-with-exclude-root.spec.ts
+++ b/packages/core/src/lib/checks/tests/deep-import-with-exclude-root.spec.ts
@@ -19,7 +19,7 @@ describe('deep imports and excludeRoot config property', () => {
       testInit('src/main.ts', {
         'tsconfig.json': tsConfig(),
         'sheriff.config.ts': sheriffConfig({
-          tagging: { 'src/shared': 'shared' },
+          modules: { 'src/shared': 'shared' },
           depRules: { '*': anyTag },
           excludeRoot,
           enableBarrelLess,

--- a/packages/core/src/lib/cli/list.ts
+++ b/packages/core/src/lib/cli/list.ts
@@ -81,7 +81,7 @@ function getTags(module: FsPath, projectInfo: ProjectInfo): string[] {
   return calcTagsForModule(
     module,
     projectInfo.rootDir,
-    projectInfo.config.tagging,
+    projectInfo.config.modules,
     projectInfo.config.autoTagging,
   );
 }

--- a/packages/core/src/lib/cli/tests/export-data.spec.ts
+++ b/packages/core/src/lib/cli/tests/export-data.spec.ts
@@ -15,7 +15,7 @@ describe('export data', () => {
     createProject({
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/<domain>/<type>': ['domain:<domain>', 'type:<type>'],
         },
         depRules: {},
@@ -98,7 +98,7 @@ describe('export data', () => {
     createProject({
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: { 'src/<scope>': 'scope:<scope>' },
+        modules: { 'src/<scope>': 'scope:<scope>' },
         depRules: {},
       }),
       src: {

--- a/packages/core/src/lib/cli/tests/list.spec.ts
+++ b/packages/core/src/lib/cli/tests/list.spec.ts
@@ -37,7 +37,7 @@ describe('list', () => {
     createProject({
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/<domain>/<type>': ['domain:<domain>', 'type:<type>'],
         },
         depRules: {},
@@ -75,7 +75,7 @@ describe('list', () => {
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
         entryFile: 'apps/eternal/src/app/main.ts',
-        tagging: {
+        modules: {
           libs: {
             'domains/<domain>/<type>': ['domain:<domain>', 'type:<type>'],
             'shared/<shared>': ['shared:<shared>'],
@@ -131,7 +131,7 @@ describe('list', () => {
     createProject({
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/<domain>/<type>': ['domain:<domain>', 'type:<type>'],
         },
         depRules: {},

--- a/packages/core/src/lib/cli/tests/verify.spec.ts
+++ b/packages/core/src/lib/cli/tests/verify.spec.ts
@@ -35,7 +35,7 @@ describe('verify', () => {
     createProject({
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/customers': ['customers'],
           'src/holidays': ['holidays'],
         },

--- a/packages/core/src/lib/config/configuration.ts
+++ b/packages/core/src/lib/config/configuration.ts
@@ -1,6 +1,6 @@
 import { UserSheriffConfig } from './user-sheriff-config';
 
-export type SheriffConfig = Required<UserSheriffConfig> & {
+export type Configuration = Required<Omit<UserSheriffConfig, 'tagging'>> & {
   // dependency rules will skip if `isConfigFileMissing` is true
   isConfigFileMissing: boolean;
 };

--- a/packages/core/src/lib/config/default-config.ts
+++ b/packages/core/src/lib/config/default-config.ts
@@ -1,9 +1,9 @@
-import { SheriffConfig } from './sheriff-config';
+import { Configuration } from './configuration';
 
-export const defaultConfig: SheriffConfig = {
+export const defaultConfig: Configuration = {
   version: 1,
   autoTagging: true,
-  tagging: {},
+  modules: {},
   depRules: {},
   excludeRoot: false,
   enableBarrelLess: false,

--- a/packages/core/src/lib/config/module-config.ts
+++ b/packages/core/src/lib/config/module-config.ts
@@ -27,6 +27,6 @@ export type TagConfigValue =
   | string[]
   | TagMatcherFn<string[] | string>;
 
-export interface TagConfig {
-  [pathMatcher: string]: TagConfigValue | TagConfig;
+export interface ModuleConfig {
+  [pathMatcher: string]: TagConfigValue | ModuleConfig;
 }

--- a/packages/core/src/lib/config/user-sheriff-config.ts
+++ b/packages/core/src/lib/config/user-sheriff-config.ts
@@ -1,4 +1,4 @@
-import { TagConfig } from './tag-config';
+import { ModuleConfig } from './module-config';
 import { DependencyRulesConfig } from './dependency-rules-config';
 
 /**
@@ -15,7 +15,7 @@ import { DependencyRulesConfig } from './dependency-rules-config';
  * import { SheriffConfig } from '@softarc/sheriff-core';
  *
  * export const config: SheriffConfig = {
- *   tags: {
+ *   modules: {
  *     src: {
  *       db: 'db',
  *       logic: 'logic',
@@ -35,7 +35,7 @@ import { DependencyRulesConfig } from './dependency-rules-config';
  * import { anyTag, SheriffConfig } from '@softarc/sheriff-core';
  *
  * export const config: SheriffConfig = {
- *   tags: {
+ *   modules: {
  *     'src/app': {
  *       'feature/<feature>': 'feature:<feature>',
  *       'shared': 'shared'
@@ -50,14 +50,62 @@ import { DependencyRulesConfig } from './dependency-rules-config';
 export interface UserSheriffConfig {
   /**
    * Tagging is not mandatory, if autoTagging is enabled (by default).
+   *
+   * @deprecated Use `modules` instead.
    */
-  tagging?: TagConfig;
+  tagging?: ModuleConfig;
+
   /**
-   * Assigns the tag "**noTag**" to all untagged modules.
+   * Defines the modules and their associated tags.
+   *
+   * Expects an object where keys represent the module paths, and each module
+   * requires one or more tags.
+   *
+   * __Example:__
+   *
+   * Given a project structure where `feature-1` and `feature-2` are modules:
+   *
+   * <pre>
+   * main.ts
+   * feature-1
+   *   ├── feature1.ts
+   *   └── internal
+   *       ├── client.ts
+   *       └── services.ts
+   * feature-2
+   *   ├── feature2.ts
+   *   └── internal
+   *       └── feature2-helper.ts
+   * </pre>
+   *
+   * The configuration for `modules` would look like this:
+   *
+   * ```typescript
+   * {
+   *   modules: {
+   *     'feature-1': ['type:feature', 'scope:global'],
+   *     'feature-2': 'type:feature2'
+   *   }
+   * }
+   * ```
+   *
+   * In this example, the `internal` folder encapsulates files, meaning they are
+   * not accessible outside the module.
+   *
+   * The assigned tags can also be used to enforce dependency rules, {@link #depRules}.
+   *
+   * If the {@link #autoTagging} property is enabled, the `modules` configuration is optional.
+   */
+  modules?: ModuleConfig;
+
+  /**
+   * Assigns the tag "**noTag**" to all untagged barrel-modules (modules with an `index.ts`).
    * Set to `true` by default.
    */
   autoTagging?: boolean;
+
   depRules: DependencyRulesConfig;
+
   // optional property. Has the value `1` by default.
   version?: number;
   /**
@@ -100,7 +148,7 @@ export interface UserSheriffConfig {
    * ```typescript
    * export const config: SheriffConfig = {
    *   excludeRoot: true,
-   *   tags: {
+   *   modules: {
    *     "src/shared": "shared",
    *   },
    *   depRules: {

--- a/packages/core/src/lib/error/user-error.ts
+++ b/packages/core/src/lib/error/user-error.ts
@@ -5,7 +5,8 @@ export type UserErrorCode =
   | 'SH-004'
   | 'SH-005'
   | 'SH-006'
-  | 'SH-007';
+  | 'SH-007'
+  | 'SH-008';
 
 export class UserError extends Error {
   constructor(
@@ -67,11 +68,20 @@ export class InvalidPlaceholderError extends UserError {
   }
 }
 
-export class MissingTaggingWithoutAutoTagging extends UserError {
+export class MissingModulesWithoutAutoTaggingError extends UserError {
   constructor() {
     super(
       'SH-007',
-      'sheriff.config.ts must have either tagging or autoTagging set to true',
+      'sheriff.config.ts must have either modules or autoTagging set to true',
+    );
+  }
+}
+
+export class TaggingAndModulesError extends UserError {
+  constructor() {
+    super(
+      'SH-008',
+      'sheriff.config.ts contains both tagging and modules. Use only modules.',
     );
   }
 }

--- a/packages/core/src/lib/eslint/eslint.spec.ts
+++ b/packages/core/src/lib/eslint/eslint.spec.ts
@@ -15,7 +15,7 @@ describe('ESLint features', () => {
       {
         'tsconfig.json': tsConfig(),
         'sheriff.config.ts': sheriffConfig({
-          tagging: { 'src/shared': 'shared' },
+          modules: { 'src/shared': 'shared' },
           depRules: { '*': anyTag },
         }),
         src: {

--- a/packages/core/src/lib/eslint/violates-dependency-rule.spec.ts
+++ b/packages/core/src/lib/eslint/violates-dependency-rule.spec.ts
@@ -13,7 +13,7 @@ describe('violates dependency rules', () => {
     createProject({
       'tsconfig.json': tsConfig(),
       'sheriff.config.ts': sheriffConfig({
-        tagging: {
+        modules: {
           'src/shared/<type>': ['shared'],
           'src/<domain>/<type>': ['domain:<domain>', 'type:<type>'],
         },
@@ -103,7 +103,7 @@ describe('violates dependency rules', () => {
   it('should show a unresolvable import', () => {
     createProject({
       'tsconfig.json': tsConfig(),
-      'sheriff.config.ts': sheriffConfig({ tagging: {}, depRules: {} }),
+      'sheriff.config.ts': sheriffConfig({ modules: {}, depRules: {} }),
       src: {
         'main.ts': ['./app.component'],
       },
@@ -122,7 +122,7 @@ describe('violates dependency rules', () => {
   it('should ignore json imports  ', () => {
     const fs = createProject({
       'tsconfig.json': tsConfig(),
-      'sheriff.config.ts': sheriffConfig({ tagging: {}, depRules: {} }),
+      'sheriff.config.ts': sheriffConfig({ modules: {}, depRules: {} }),
       src: {
         'main.ts': ['./data.json'],
         'data.json': [],

--- a/packages/core/src/lib/log/log.module.spec.ts
+++ b/packages/core/src/lib/log/log.module.spec.ts
@@ -18,7 +18,7 @@ describe('log', () => {
       {
         'tsconfig.json': tsConfig(),
         'sheriff.config.ts': sheriffConfig({
-          tagging: {},
+          modules: {},
           depRules: {},
           log: enableLog,
         }),

--- a/packages/core/src/lib/main/after-init.ts
+++ b/packages/core/src/lib/main/after-init.ts
@@ -1,9 +1,9 @@
-import { SheriffConfig } from '../config/sheriff-config';
+import { Configuration } from '../config/configuration';
 import { initialized } from './internal/initialized';
 import { callbacks } from './internal/callback';
 
 export function afterInit(
-  callback: (config: SheriffConfig | undefined) => void,
+  callback: (config: Configuration | undefined) => void,
 ) {
   if (initialized.status) {
     callback(initialized.config);

--- a/packages/core/src/lib/main/callback.ts
+++ b/packages/core/src/lib/main/callback.ts
@@ -1,3 +1,3 @@
-import { SheriffConfig } from '../config/sheriff-config';
+import { Configuration } from '../config/configuration';
 
-export type Callback = (config: SheriffConfig | undefined) => void;
+export type Callback = (config: Configuration | undefined) => void;

--- a/packages/core/src/lib/main/init.ts
+++ b/packages/core/src/lib/main/init.ts
@@ -1,5 +1,5 @@
 import { FsPath, toFsPath } from '../file-info/fs-path';
-import { SheriffConfig } from '../config/sheriff-config';
+import { Configuration } from '../config/configuration';
 import { TsData } from '../file-info/ts-data';
 import getFs from '../fs/getFs';
 import { generateTsData } from '../file-info/generate-ts-data';
@@ -10,11 +10,11 @@ import { initialized } from './internal/initialized';
 import { callbacks } from './internal/callback';
 import { defaultConfig } from '../config/default-config';
 
-let config: SheriffConfig | undefined;
+let config: Configuration | undefined;
 
 export type ProjectInfo = {
   tsData: TsData;
-  config: SheriffConfig;
+  config: Configuration;
 } & ParsedResult;
 
 /**
@@ -98,7 +98,7 @@ export function init(entryFile: FsPath, options: InitOptions = {}) {
   };
 }
 
-function getConfig(rootPath: FsPath): SheriffConfig {
+function getConfig(rootPath: FsPath): Configuration {
   const configFile = findConfig(rootPath);
   if (configFile) {
     return parseConfig(configFile);

--- a/packages/core/src/lib/main/internal/initialized.ts
+++ b/packages/core/src/lib/main/internal/initialized.ts
@@ -1,6 +1,6 @@
-import { SheriffConfig } from '../../config/sheriff-config';
+import { Configuration } from '../../config/configuration';
 
 export const initialized: {
   status: boolean;
-  config: SheriffConfig | undefined;
+  config: Configuration | undefined;
 } = { status: false, config: undefined };

--- a/packages/core/src/lib/main/parse-project.ts
+++ b/packages/core/src/lib/main/parse-project.ts
@@ -7,7 +7,7 @@ import { fillFileInfoMap } from '../modules/fill-file-info-map';
 import throwIfNull from '../util/throw-if-null';
 import { TsData } from '../file-info/ts-data';
 import { Module } from '../modules/module';
-import { SheriffConfig } from '../config/sheriff-config';
+import { Configuration } from '../config/configuration';
 import { findModulePaths } from '../modules/find-module-paths';
 
 export type ParsedResult = {
@@ -21,7 +21,7 @@ export const parseProject = (
   entryFile: FsPath,
   traverse: boolean,
   tsData: TsData,
-  config: SheriffConfig,
+  config: Configuration,
   fileContent?: string,
 ): ParsedResult => {
   const unassignedFileInfo = generateUnassignedFileInfo(

--- a/packages/core/src/lib/modules/find-module-paths.ts
+++ b/packages/core/src/lib/modules/find-module-paths.ts
@@ -1,7 +1,7 @@
 import { FsPath } from '../file-info/fs-path';
 import { findModulePathsWithBarrel } from './internal/find-module-paths-with-barrel';
 import { findModulePathsWithoutBarrel } from './internal/find-module-paths-without-barrel';
-import { SheriffConfig } from '../config/sheriff-config';
+import { Configuration } from '../config/configuration';
 
 export type ModulePathMap = Record<FsPath, boolean>;
 
@@ -14,15 +14,15 @@ export type ModulePathMap = Record<FsPath, boolean>;
 export function findModulePaths(
   projectDirs: FsPath[],
   rootDir: FsPath,
-  sheriffConfig: SheriffConfig,
+  sheriffConfig: Configuration,
 ): ModulePathMap {
   const {
-    tagging,
+    modules,
     enableBarrelLess,
     barrelFileName
   } = sheriffConfig;
   const modulesWithoutBarrel = enableBarrelLess
-    ? findModulePathsWithoutBarrel(tagging, rootDir, barrelFileName)
+    ? findModulePathsWithoutBarrel(modules, rootDir, barrelFileName)
     : [];
   const modulesWithBarrel = findModulePathsWithBarrel(
     projectDirs,

--- a/packages/core/src/lib/modules/internal/find-module-paths-without-barrel.ts
+++ b/packages/core/src/lib/modules/internal/find-module-paths-without-barrel.ts
@@ -1,4 +1,4 @@
-import { TagConfig } from '../../config/tag-config';
+import { ModuleConfig } from '../../config/module-config';
 import { FsPath } from '../../file-info/fs-path';
 import {
   createModulePathPatternsTree,
@@ -6,7 +6,7 @@ import {
 } from './create-module-path-patterns-tree';
 import getFs from '../../fs/getFs';
 import { FOLDER_CHARACTERS_REGEX_STRING } from '../../tags/calc-tags-for-module';
-import { flattenTagging } from './flatten-tagging';
+import { flattenModules } from './flatten-modules';
 
 /**
  * The current criterion for finding modules is via
@@ -16,11 +16,11 @@ import { flattenTagging } from './flatten-tagging';
  * against the patterns.
  */
 export function findModulePathsWithoutBarrel(
-  moduleConfig: TagConfig,
+  moduleConfig: ModuleConfig,
   rootDir: FsPath,
   barrelFileName: string
 ): Set<FsPath> {
-  const paths = flattenTagging(moduleConfig, '');
+  const paths = flattenModules(moduleConfig, '');
   const modulePathsPatternTree = createModulePathPatternsTree(paths);
   const modules = traverseAndMatch(modulePathsPatternTree, rootDir, barrelFileName);
   return new Set<FsPath>(modules);

--- a/packages/core/src/lib/modules/internal/flatten-modules.ts
+++ b/packages/core/src/lib/modules/internal/flatten-modules.ts
@@ -1,7 +1,7 @@
-import { TagConfig } from '../../config/tag-config';
+import { ModuleConfig } from '../../config/module-config';
 import { PLACE_HOLDER_REGEX } from "../../tags/calc-tags-for-module";
 
-export function flattenTagging(tagging: TagConfig, prefix = ''): string[] {
+export function flattenModules(tagging: ModuleConfig, prefix = ''): string[] {
   let flattened: string[] = [];
   for (const [rawPath, value] of Object.entries(tagging)) {
     const path = rawPath.replace(PLACE_HOLDER_REGEX, '*');
@@ -13,7 +13,7 @@ export function flattenTagging(tagging: TagConfig, prefix = ''): string[] {
     ) {
       flattened.push(fullPath);
     } else {
-      flattened = [...flattened, ...flattenTagging(value, fullPath)];
+      flattened = [...flattened, ...flattenModules(value, fullPath)];
     }
   }
 

--- a/packages/core/src/lib/modules/tests/create-module.spec.ts
+++ b/packages/core/src/lib/modules/tests/create-module.spec.ts
@@ -231,7 +231,7 @@ describe('createModule', () => {
           src: {
             'tsconfig.json': tsConfig(),
             'sheriff.config.ts': sheriffConfig({
-              tagging: { customer: 'domain:customer' },
+              modules: { customer: 'domain:customer' },
               depRules: {},
               enableBarrelLess: true,
               showWarningOnBarrelCollision,

--- a/packages/core/src/lib/modules/tests/find-module-paths-without-barrel.spec.ts
+++ b/packages/core/src/lib/modules/tests/find-module-paths-without-barrel.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { FileTree } from '../../test/project-configurator';
-import { TagConfig } from '../../config/tag-config';
+import { ModuleConfig } from '../../config/module-config';
 import { createProject } from '../../test/project-creator';
 import { findModulePathsWithoutBarrel } from '../internal/find-module-paths-without-barrel';
 import { useVirtualFs } from '../../fs/getFs';
@@ -8,7 +8,7 @@ import { toFsPath } from '../../file-info/fs-path';
 
 function assertProject(fileTree: FileTree) {
   return {
-    withModuleConfig(moduleConfig: TagConfig) {
+    withModuleConfig(moduleConfig: ModuleConfig) {
       return {
         hasModulePaths(modulePaths: string[]) {
           const absoluteModulePaths = modulePaths.map(

--- a/packages/core/src/lib/modules/tests/flatten-tagging.spec.ts
+++ b/packages/core/src/lib/modules/tests/flatten-tagging.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { TagConfig } from '../../config/tag-config';
-import { flattenTagging } from "../internal/flatten-tagging";
+import { ModuleConfig } from '../../config/module-config';
+import { flattenModules } from "../internal/flatten-modules";
 
 describe('flatten tags', () => {
   it('should flatten', () => {
-    const tagging: TagConfig = {
+    const tagging: ModuleConfig = {
       'src/app': {
         customer: ['domain:customer'],
         holidays: 'domain:holidays',
@@ -12,7 +12,7 @@ describe('flatten tags', () => {
       },
     };
 
-    expect(flattenTagging(tagging)).toEqual([
+    expect(flattenModules(tagging)).toEqual([
       'src/app/customer',
       'src/app/holidays',
       'src/app/bookings',
@@ -20,7 +20,7 @@ describe('flatten tags', () => {
   });
 
   it('should flatten mixed hierarchy', () => {
-    const tagging: TagConfig = {
+    const tagging: ModuleConfig = {
       src: {
         app: {
           customer: { feature: 'domain:customer' },
@@ -31,7 +31,7 @@ describe('flatten tags', () => {
         },
       },
     };
-    expect(flattenTagging(tagging)).toEqual([
+    expect(flattenModules(tagging)).toEqual([
       'src/app/customer/feature',
       'src/app/holidays',
       'src/lib/shared',
@@ -40,14 +40,14 @@ describe('flatten tags', () => {
 
 
   it('should mark tags as *', () => {
-    const tagging: TagConfig = {
+    const tagging: ModuleConfig = {
       src: {
         app: {
           customer: { 'feat-<feature>': 'feature', '<type>': '<type>' },
         },
       },
     };
-    expect(flattenTagging(tagging)).toEqual([
+    expect(flattenModules(tagging)).toEqual([
       'src/app/customer/feat-*',
       'src/app/customer/*',
     ]);
@@ -55,7 +55,7 @@ describe('flatten tags', () => {
 
 
   it('should flatten nested modules', () => {
-    const tagging: TagConfig = {
+    const tagging: ModuleConfig = {
       src: {
         'lib/customer': 'nx',
         lib: {
@@ -66,7 +66,7 @@ describe('flatten tags', () => {
         },
       },
     };
-    expect(flattenTagging(tagging)).toEqual([
+    expect(flattenModules(tagging)).toEqual([
       'src/lib/customer',
       'src/lib/customer/*',
       'src/lib/shared',

--- a/packages/core/src/lib/tags/calc-tags-for-module.ts
+++ b/packages/core/src/lib/tags/calc-tags-for-module.ts
@@ -1,8 +1,8 @@
 import {
   MatcherContext,
-  TagConfig,
+  ModuleConfig,
   TagConfigValue,
-} from '../config/tag-config';
+} from '../config/module-config';
 import getFs from '../fs/getFs';
 import { FsPath } from '../file-info/fs-path';
 import {
@@ -18,7 +18,7 @@ export const PLACE_HOLDER_REGEX = /<[a-zA-Z-_]+>/g;
 export const calcTagsForModule = (
   moduleDir: FsPath,
   rootDir: FsPath,
-  tagConfig: TagConfig,
+  moduleConfig: ModuleConfig,
   autoTagging = true,
 ): string[] => {
   if (moduleDir === rootDir) {
@@ -28,9 +28,9 @@ export const calcTagsForModule = (
   const paths = fs.split(moduleDir.slice(rootDir.length + 1));
   const placeholders: Record<string, string> = {};
 
-  const tags = traverseTagConfig(
+  const tags = traverseModuleConfig(
     paths,
-    tagConfig,
+    moduleConfig,
     placeholders,
     moduleDir,
     [],
@@ -48,9 +48,9 @@ export const calcTagsForModule = (
   return tags;
 };
 
-function traverseTagConfig(
+function traverseModuleConfig(
   paths: string[],
-  tagConfig: TagConfig,
+  tagConfig: ModuleConfig,
   placeholders: Record<string, string>,
   moduleDir: string,
   tagConfigPath: string[],
@@ -105,7 +105,7 @@ function traverseTagConfig(
         continue;
       }
 
-      return traverseTagConfig(
+      return traverseModuleConfig(
         restPaths,
         value,
         placeholders,
@@ -120,13 +120,13 @@ function traverseTagConfig(
 }
 
 function isTagConfigValue(
-  value: TagConfigValue | TagConfig,
+  value: TagConfigValue | ModuleConfig,
 ): value is TagConfigValue {
   return !(typeof value === 'object' && !Array.isArray(value));
 }
 
 function assertLeafHasTag(
-  value: TagConfigValue | TagConfig,
+  value: TagConfigValue | ModuleConfig,
   tagConfigPath: string[],
 ): asserts value is TagConfigValue {
   if (!isTagConfigValue(value)) {

--- a/packages/core/src/lib/test/project-creator.ts
+++ b/packages/core/src/lib/test/project-creator.ts
@@ -3,7 +3,7 @@ import { EOL } from 'os';
 import * as crypto from 'crypto';
 import getFs, { useVirtualFs } from '../fs/getFs';
 import { toFsPath } from '../file-info/fs-path';
-import { SheriffConfig } from '../config/sheriff-config';
+import { Configuration } from '../config/configuration';
 import { defaultConfig } from '../config/default-config';
 import { Fs } from '../fs/fs';
 
@@ -61,7 +61,7 @@ class ProjectCreator {
   };
 }
 
-function serializeDepRules(config: SheriffConfig): SheriffConfig {
+function serializeDepRules(config: Configuration): Configuration {
   return {
     ...config,
     depRules: Object.entries(config.depRules).reduce(


### PR DESCRIPTION
With barrel-less modules, modules are not defined by the existence of a barrel file but by the `config` itself. The term `tagging` doesn't reflect the new context anymore, as it doesn't just tag but also specify modules.

Therefore, `tagging` is deprecated and still works, but for new configs, `modules` should be used instead.