### PR TITLE
Feat/exclude sherif.config.ts from sheriff eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ const unusedImports = require('eslint-plugin-unused-imports');
 module.exports = tseslint.config(
   ...tseslint.configs.recommended,
   {
-    files: ['*.json', '*.html', '*.ts'],
+    files: ['*.html', '*.ts'],
     extends: [prettierRecommended],
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ const unusedImports = require('eslint-plugin-unused-imports');
 module.exports = tseslint.config(
   ...tseslint.configs.recommended,
   {
-    files: ['*.html', '*.ts'],
+    files: ['*.json', '*.html', '*.ts'],
     extends: [prettierRecommended],
   },
   {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:all": "npx nx run-many --target=build && chmod +x dist/packages/core/src/bin/main.js",
     "commit": "commit",
     "lint:all": "eslint ./packages",
-    "link:sheriff": "npm run build:all && yalc publish dist/packages/core && yalc publish dist/packages/eslint-plugin && yalc link @softarc/sheriff-core @softarc/eslint-plugin-sheriff",
+    "link:sheriff": "yarn run build:all && yalc publish dist/packages/core && yalc publish dist/packages/eslint-plugin && yalc link @softarc/sheriff-core @softarc/eslint-plugin-sheriff",
     "run:cli": "nx build core && chmod +x dist/packages/core/src/bin/main.js",
     "test": "vitest",
     "test:ci": "vitest -c vitest.config.ci.ts"

--- a/packages/eslint-plugin/src/lib/configs/all.ts
+++ b/packages/eslint-plugin/src/lib/configs/all.ts
@@ -1,7 +1,9 @@
-import rules from '../rules';
 import type { TSESLint } from '@typescript-eslint/utils';
+import rules from '../rules';
 
-export const barrelModulesOnly: TSESLint.FlatConfig.Config = {
+const commonConfig: TSESLint.FlatConfig.Config = {
+  files: ['*.ts, *.js'],
+  ignores: ['sheriff.config.ts'],
   languageOptions: {
     sourceType: 'module',
   },
@@ -10,22 +12,18 @@ export const barrelModulesOnly: TSESLint.FlatConfig.Config = {
       rules,
     },
   },
+};
+
+export const barrelModulesOnly: TSESLint.FlatConfig.Config = {
+  ...commonConfig,
   rules: {
     '@softarc/sheriff/dependency-rule': 'error',
     '@softarc/sheriff/deep-import': 'error',
   },
 };
 
-
 export const all: TSESLint.FlatConfig.Config = {
-  languageOptions: {
-    sourceType: 'module',
-  },
-  plugins: {
-    '@softarc/sheriff': {
-      rules,
-    },
-  },
+  ...commonConfig,
   rules: {
     '@softarc/sheriff/dependency-rule': 'error',
     '@softarc/sheriff/encapsulation': 'error',

--- a/packages/eslint-plugin/src/lib/configs/legacy.ts
+++ b/packages/eslint-plugin/src/lib/configs/legacy.ts
@@ -1,13 +1,8 @@
 import { ESLint } from 'eslint';
 
-const commonConfig: ESLint.ConfigData = {
+export const legacyBarrelModulesOnly: ESLint.ConfigData = {
   parser: '@typescript-eslint/parser',
   plugins: ['@softarc/sheriff'],
-  ignorePatterns: ['sheriff.config.ts'],
-};
-
-export const legacyBarrelModulesOnly: ESLint.ConfigData = {
-  ...commonConfig,
   rules: {
     '@softarc/sheriff/dependency-rule': 'error',
     '@softarc/sheriff/deep-import': 'error',
@@ -15,7 +10,8 @@ export const legacyBarrelModulesOnly: ESLint.ConfigData = {
 };
 
 export const legacy: ESLint.ConfigData = {
-  ...commonConfig,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@softarc/sheriff'],
   rules: {
     '@softarc/sheriff/dependency-rule': 'error',
     '@softarc/sheriff/encapsulation': 'error',

--- a/packages/eslint-plugin/src/lib/configs/legacy.ts
+++ b/packages/eslint-plugin/src/lib/configs/legacy.ts
@@ -1,20 +1,23 @@
-import { ESLint } from "eslint";
+import { ESLint } from 'eslint';
 
-export const legacyBarrelModulesOnly: ESLint.ConfigData = {
+const commonConfig: ESLint.ConfigData = {
   parser: '@typescript-eslint/parser',
   plugins: ['@softarc/sheriff'],
+  ignorePatterns: ['sheriff.config.ts'],
+};
+
+export const legacyBarrelModulesOnly: ESLint.ConfigData = {
+  ...commonConfig,
   rules: {
     '@softarc/sheriff/dependency-rule': 'error',
     '@softarc/sheriff/deep-import': 'error',
   },
-}
+};
 
 export const legacy: ESLint.ConfigData = {
-  parser: '@typescript-eslint/parser',
-  plugins: ['@softarc/sheriff'],
+  ...commonConfig,
   rules: {
     '@softarc/sheriff/dependency-rule': 'error',
     '@softarc/sheriff/encapsulation': 'error',
   },
-}
-
+};

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,5 +1,4 @@
 {
   "extends": "./tsconfig.base.json",
   "include": ["**/*.spec.ts"]
-  ]
 }


### PR DESCRIPTION
Per your comment, 1st bullet point: https://github.com/softarc-consulting/sheriff/issues/161#issuecomment-2481411348

This PR adds the ignores property internally to eslint config imported by the user. No need to tell the user how to do it themselves in the docs.

Of my two PRs this is the simplest but the least testable. 