### PR TITLE
Feature/remove sheriff.config from lint programatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:all": "npx nx run-many --target=build && chmod +x dist/packages/core/src/bin/main.js",
     "commit": "commit",
     "lint:all": "eslint ./packages",
-    "link:sheriff": "npm run build:all && yalc publish dist/packages/core && yalc publish dist/packages/eslint-plugin && yalc link @softarc/sheriff-core @softarc/eslint-plugin-sheriff",
+    "link:sheriff": "yarn run build:all && yalc publish dist/packages/core && yalc publish dist/packages/eslint-plugin && yalc link @softarc/sheriff-core @softarc/eslint-plugin-sheriff",
     "run:cli": "nx build core && chmod +x dist/packages/core/src/bin/main.js",
     "test": "vitest",
     "test:ci": "vitest -c vitest.config.ci.ts"

--- a/packages/eslint-plugin/src/lib/rules/create-rule.ts
+++ b/packages/eslint-plugin/src/lib/rules/create-rule.ts
@@ -21,16 +21,16 @@ export const createRule: (
   executor: Executor,
 ) => Rule.RuleModule = (ruleName, fileFilter, executor) => ({
   create: (context) => {
+    const filename = context.filename ?? context.getFilename();
+    if (isExcluded(fileFilter, filename)) {
+      return {};
+    }
+
     let isFirstRun = true;
     let hasInternalError = false;
     const executeRuleWithContext = (node: ExecutorNode) => {
-      const filename = context.filename ?? context.getFilename();
       const sourceCode =
         context.sourceCode?.text ?? context.getSourceCode().text;
-
-      if (isExcluded(fileFilter, filename)) {
-        return;
-      }
 
       if (!hasInternalError) {
         try {

--- a/packages/eslint-plugin/src/lib/rules/deep-import.ts
+++ b/packages/eslint-plugin/src/lib/rules/deep-import.ts
@@ -1,8 +1,10 @@
 import { violatesEncapsulationRule } from '@softarc/sheriff-core';
 import { createRule } from './create-rule';
+import { excludeSheriffConfig } from './file-filter';
 
 export const deepImport = createRule(
   'Deep Import',
+  excludeSheriffConfig,
   (context, node, isFirstRun, filename, sourceCode) => {
     const importValue = (node.source as { value: string }).value;
     const message = violatesEncapsulationRule(
@@ -10,7 +12,7 @@ export const deepImport = createRule(
       importValue,
       isFirstRun,
       sourceCode,
-      true
+      true,
     );
     if (message) {
       context.report({

--- a/packages/eslint-plugin/src/lib/rules/dependency-rule.ts
+++ b/packages/eslint-plugin/src/lib/rules/dependency-rule.ts
@@ -1,8 +1,10 @@
 import { violatesDependencyRule } from '@softarc/sheriff-core';
 import { createRule } from './create-rule';
+import { excludeSheriffConfig } from './file-filter';
 
 export const dependencyRule = createRule(
   'Dependency Rule',
+  excludeSheriffConfig,
   (context, node, isFirstRun, filename, sourceCode) => {
     const importValue = (node.source as { value: string }).value;
     const message = violatesDependencyRule(

--- a/packages/eslint-plugin/src/lib/rules/encapsulation.ts
+++ b/packages/eslint-plugin/src/lib/rules/encapsulation.ts
@@ -1,8 +1,10 @@
 import { violatesEncapsulationRule } from '@softarc/sheriff-core';
 import { createRule } from './create-rule';
+import { excludeSheriffConfig } from './file-filter';
 
 export const encapsulation = createRule(
   'Encapsulation',
+  excludeSheriffConfig,
   (context, node, isFirstRun, filename, sourceCode) => {
     const importValue = (node.source as { value: string }).value;
     const message = violatesEncapsulationRule(
@@ -10,7 +12,7 @@ export const encapsulation = createRule(
       importValue,
       isFirstRun,
       sourceCode,
-      false
+      false,
     );
     if (message) {
       context.report({

--- a/packages/eslint-plugin/src/lib/rules/file-filter.ts
+++ b/packages/eslint-plugin/src/lib/rules/file-filter.ts
@@ -3,7 +3,7 @@ export interface FileFilter {
   exclude?: string[];
 }
 
-const sheriffConfigFileName = 'sheriff.config.ts';
+export const sheriffConfigFileName = 'sheriff.config.ts';
 
 export const excludeSheriffConfig: FileFilter = {
   exclude: [sheriffConfigFileName],

--- a/packages/eslint-plugin/src/lib/rules/file-filter.ts
+++ b/packages/eslint-plugin/src/lib/rules/file-filter.ts
@@ -1,0 +1,14 @@
+export interface FileFilter {
+  include?: string[];
+  exclude?: string[];
+}
+
+const sheriffConfigFileName = 'sheriff.config.ts';
+
+export const excludeSheriffConfig: FileFilter = {
+  exclude: [sheriffConfigFileName],
+};
+
+export const onlySheriffConfig: FileFilter = {
+  include: [sheriffConfigFileName],
+};

--- a/packages/eslint-plugin/src/lib/rules/tests/create-rule.spec.ts
+++ b/packages/eslint-plugin/src/lib/rules/tests/create-rule.spec.ts
@@ -3,7 +3,7 @@ import { RuleTester } from 'eslint';
 import { parser } from 'typescript-eslint';
 import { afterEach, describe, expect, it, vitest } from 'vitest';
 import { createRule } from '../create-rule';
-import { excludeSheriffConfig } from '../file-filter';
+import { excludeSheriffConfig, sheriffConfigFileName } from '../file-filter';
 
 const tester = new RuleTester({
   languageOptions: { parser, sourceType: 'module' },
@@ -33,6 +33,21 @@ describe('create rule', () => {
       invalid: [],
     });
     expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it.only('should NOT call the rule executor for any import or export types when filename is "sheriff.config.ts"', () => {
+    tester.run('test-rule', testRule, {
+      valid: [
+        {
+          filename: sheriffConfigFileName,
+          code: `import {AppComponent} from './app.component'
+      const a = new AppComponent();
+      import('../util.ts')`,
+        },
+      ],
+      invalid: [],
+    });
+    expect(spy).toHaveBeenCalledTimes(0);
   });
 
   for (const { throwing, message } of [

--- a/packages/eslint-plugin/src/lib/rules/tests/create-rule.spec.ts
+++ b/packages/eslint-plugin/src/lib/rules/tests/create-rule.spec.ts
@@ -1,17 +1,18 @@
+import { UserError } from '@softarc/sheriff-core';
 import { RuleTester } from 'eslint';
+import { parser } from 'typescript-eslint';
 import { afterEach, describe, expect, it, vitest } from 'vitest';
 import { createRule } from '../create-rule';
-import { UserError } from '@softarc/sheriff-core';
-import { parser } from 'typescript-eslint';
+import { excludeSheriffConfig } from '../file-filter';
 
 const tester = new RuleTester({
-  languageOptions: { parser, sourceType: 'module' }
+  languageOptions: { parser, sourceType: 'module' },
 });
 
 const ruleExecutor = { foo: () => void true };
 const spy = vitest.spyOn(ruleExecutor, 'foo');
 
-export const testRule = createRule('Test Rule', () => {
+export const testRule = createRule('Test Rule', excludeSheriffConfig, () => {
   ruleExecutor.foo();
 });
 
@@ -84,7 +85,7 @@ describe('create rule', () => {
           `,
         },
       ],
-      invalid: []
+      invalid: [],
     });
 
     expect(spy).toHaveBeenCalledTimes(2);

--- a/packages/eslint-plugin/src/lib/rules/tests/create-rule.spec.ts
+++ b/packages/eslint-plugin/src/lib/rules/tests/create-rule.spec.ts
@@ -35,7 +35,7 @@ describe('create rule', () => {
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
-  it.only('should NOT call the rule executor for any import or export types when filename is "sheriff.config.ts"', () => {
+  it('should NOT call the rule executor for any import or export types when filename is "sheriff.config.ts"', () => {
     tester.run('test-rule', testRule, {
       valid: [
         {

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,5 +1,4 @@
 {
   "extends": "./tsconfig.base.json",
   "include": ["**/*.spec.ts"]
-  ]
 }


### PR DESCRIPTION
Per your comment, 2nd bullet point: https://github.com/softarc-consulting/sheriff/issues/161#issuecomment-2481411348

This PR adds the ability for rules to have a filename inclusions or exclusions list set inside the `createRule` factory and filters the 'sheriff.config.ts' file from all the existing rules. This allows a future set of rules that can be filename/type-specific.

Of my two PRs this is the most testable, but both are written with consideration to solving https://github.com/softarc-consulting/sheriff/issues/165.