### PR TITLE
fix: resolve "extends" property correctly when using an alias

### DIFF
--- a/packages/core/src/lib/error/user-error.ts
+++ b/packages/core/src/lib/error/user-error.ts
@@ -7,7 +7,8 @@ export type UserErrorCode =
   | 'SH-006'
   | 'SH-007'
   | 'SH-008'
-  | 'SH-009';
+  | 'SH-009'
+  | 'SH-010';
 
 export class UserError extends Error {
   constructor(
@@ -92,6 +93,15 @@ export class CollidingEncapsulationSettings extends UserError {
     super(
       'SH-009',
       'sheriff.config.ts contains both encapsulatedFolderNameForBarrelLess and encapsulationPatternForBarrellLess. Use encapsulationPatternForBarrellLess.',
+    );
+  }
+}
+
+export class TsExtendsResolutionError extends UserError {
+  constructor(tsConfigPath: string, extendsPath: string) {
+    super(
+      'SH-010',
+      `Cannot resolve path ${extendsPath} of "extends" property in ${tsConfigPath}. Please verify that the path exists.`,
     );
   }
 }

--- a/packages/core/src/lib/file-info/fix-path-separators.ts
+++ b/packages/core/src/lib/file-info/fix-path-separators.ts
@@ -1,0 +1,17 @@
+import { FsPath, toFsPath } from './fs-path';
+import getFs from '../fs/getFs';
+
+/**
+ * Ensures that `FsPath` uses the separator from the OS and not always '/'
+ *
+ * @param path
+ */
+export function fixPathSeparators(path: string): FsPath {
+  const fs = getFs();
+
+  if (fs.pathSeparator !== '/') {
+    return toFsPath(path.replace(/\//g, fs.pathSeparator));
+  }
+
+  return toFsPath(path);
+}

--- a/packages/core/src/lib/file-info/resolve-potential-ts-path.ts
+++ b/packages/core/src/lib/file-info/resolve-potential-ts-path.ts
@@ -1,0 +1,88 @@
+import { TsPaths } from './ts-data';
+import { FsPath, isFsPath, toFsPath } from './fs-path';
+import { ResolveFn } from './traverse-filesystem';
+import getFs from '../fs/getFs';
+import { fixPathSeparators } from './fix-path-separators';
+
+/**
+ * Resolves a import statements which use a TypeScript alias.
+ * If resolving does not work, it returns an undefined.
+ *
+ * It only works if the import state is using aliases from tsconfig.json.
+ *
+ * ```typescript
+ * import { AppComponent } from '@app/app.component';
+ * ```
+ *
+ * @param moduleName name as it is in the import statement, e.g. '../app.component'
+ * @param tsPaths resolved paths from the tsconfig.json file
+ * @param resolveFn function to resolve the path, built-in TypeScript resolver
+ */
+export function resolvePotentialTsPath(
+  moduleName: string,
+  tsPaths: TsPaths,
+  resolveFn: ResolveFn,
+): FsPath | undefined {
+  let unpathedImport: string | undefined;
+  for (const tsPath in tsPaths) {
+    const { isWildcard, clearedTsPath } = clearTsPath(tsPath);
+    // import from '@app/app.component' & paths: {'@app/*': ['src/app/*']}
+    if (isWildcard && moduleName.startsWith(clearedTsPath)) {
+      const pathMapping = tsPaths[tsPath];
+      unpathedImport = moduleName.replace(clearedTsPath, pathMapping);
+    }
+    // import from '@app' & paths: { '@app': [''] }
+    else if (tsPath === moduleName) {
+      unpathedImport = tsPaths[tsPath];
+    }
+
+    // current path applies -> resolve it
+    if (unpathedImport) {
+      // path is file -> return as is
+      if (isPathFile(unpathedImport)) {
+        return fixPathSeparators(toFsPath(unpathedImport));
+      }
+      // path is directory or something else -> rely on TypeScript resolvers
+      else {
+        const resolvedImport = resolveFn(unpathedImport);
+        // if path applies but import is for external library with same time,
+        // we need to rely on the native TypeScript resolver, which is done
+        // outside the path resolving.
+        if (resolvedImport.resolvedModule) {
+          return toFsPath(
+            fixPathSeparators(resolvedImport.resolvedModule.resolvedFileName),
+          );
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function clearTsPath(tsPath: string) {
+  const [isWildcard, clearedPath] = tsPath.endsWith('/*')
+    ? [true, tsPath.slice(0, -2)]
+    : [false, tsPath];
+  return { isWildcard, clearedTsPath: clearedPath };
+}
+
+/**
+ * Checks if the path is a file.
+ *
+ * For example in tsconfig.json:
+ * ```json
+ *   "paths": {
+ *     "@app": ["src/app/index"]
+ *   }
+ * ```
+ *
+ * 'src/app/index' comes already as absolute path with ts extension from
+ * pre-processing of @generateTsData.
+ *
+ * @param path '/.../src/app/index.ts' according to the example above
+ */
+function isPathFile(path: string): boolean {
+  const fs = getFs();
+  return fs.exists(path) && isFsPath(path) && fs.isFile(path);
+}

--- a/packages/core/src/lib/file-info/tests/get-ts-config-context.spec.ts
+++ b/packages/core/src/lib/file-info/tests/get-ts-config-context.spec.ts
@@ -1,258 +1,369 @@
-import { createProject } from "../../test/project-creator";
-import { toFsPath } from "../fs-path";
-import { getTsConfigContext } from "../get-ts-config-context";
-import { InvalidPathError } from "../../error/user-error";
-import { fullTsConfig, tsConfig } from "../../test/fixtures/ts-config";
+import { createProject } from '../../test/project-creator';
+import { toFsPath } from '../fs-path';
+import { getTsConfigContext } from '../get-ts-config-context';
+import {
+  InvalidPathError,
+  TsExtendsResolutionError,
+} from '../../error/user-error';
+import { fullTsConfig, tsConfig } from '../../test/fixtures/ts-config';
 import { describe, it, expect, test } from 'vitest';
+import '../../test/expect.extensions';
 
-describe("getTsConfigContext", () => {
+describe('getTsConfigContext', () => {
   for (const { name, tsPaths, fsPaths } of [
     {
-      name: "default paths",
+      name: 'default paths',
       tsPaths: {
-        "@app/*": ["src/app"],
-        "@customers": ["src/app/customers/index.ts"],
-        "@holidays": ["src/app/holidays/index.ts"]
+        '@app/*': ['src/app'],
+        '@customers': ['src/app/customers/index.ts'],
+        '@holidays': ['src/app/holidays/index.ts'],
       },
       fsPaths: {
-        "@app/*": "/project/src/app",
-        "@customers": "/project/src/app/customers/index.ts",
-        "@holidays": "/project/src/app/holidays/index.ts"
-      }
+        '@app/*': '/project/src/app',
+        '@customers': '/project/src/app/customers/index.ts',
+        '@holidays': '/project/src/app/holidays/index.ts',
+      },
     },
     {
-      name: "directory path",
+      name: 'directory path',
       tsPaths: {
-        "@customers": ["src/app/customers"]
+        '@customers': ['src/app/customers'],
       },
       fsPaths: {
-        "@customers": "/project/src/app/customers"
-      }
+        '@customers': '/project/src/app/customers',
+      },
     },
     {
-      name: "file without extension path",
+      name: 'file without extension path',
       tsPaths: {
-        "@customers": ["src/app/customers/index"]
+        '@customers': ['src/app/customers/index'],
       },
       fsPaths: {
-        "@customers": "/project/src/app/customers/index.ts"
-      }
-    }
+        '@customers': '/project/src/app/customers/index.ts',
+      },
+    },
   ]) {
     test(name, () => {
       createProject({
-        "tsconfig.json": tsConfig({ paths: tsPaths }),
+        'tsconfig.json': tsConfig({ paths: tsPaths }),
         src: {
           app: {
-            "main.ts": [],
+            'main.ts': [],
             customers: {
-              "index.ts": []
+              'index.ts': [],
             },
             holidays: {
-              "index.ts": []
-            }
-          }
-        }
+              'index.ts': [],
+            },
+          },
+        },
       });
 
       expect(
-        getTsConfigContext(toFsPath("/project/tsconfig.json")).paths
+        getTsConfigContext(toFsPath('/project/tsconfig.json')).paths,
       ).toEqual(fsPaths);
     });
   }
 
   for (const { name, tsPaths, errorParams } of [
     {
-      name: "not existing path",
+      name: 'not existing path',
       tsPaths: {
-        "@app": ["src/app/sdf"]
+        '@app': ['src/app/sdf'],
       },
-      errorParams: ["@app", "src/app/sdf"]
+      errorParams: ['@app', 'src/app/sdf'],
     },
     {
-      name: "not existing file",
+      name: 'not existing file',
       tsPaths: {
-        "@main": ["src/app/index"]
+        '@main': ['src/app/index'],
       },
-      errorParams: ["@main", "src/app/index"]
+      errorParams: ['@main', 'src/app/index'],
     },
     {
-      name: "not existing path with wildcard",
+      name: 'not existing path with wildcard',
       tsPaths: {
-        "@app/*": ["src/app/somewhere"]
+        '@app/*': ['src/app/somewhere'],
       },
-      errorParams: ["@app/*", "src/app/somewhere"]
-    }
+      errorParams: ['@app/*', 'src/app/somewhere'],
+    },
   ]) {
     test(name, () => {
       createProject({
-        "tsconfig.json": tsConfig({ paths: tsPaths }),
+        'tsconfig.json': tsConfig({ paths: tsPaths }),
         src: {
           app: {
-            "main.ts": [],
+            'main.ts': [],
             customers: {
-              "index.ts": []
+              'index.ts': [],
             },
             holidays: {
-              "index.ts": []
-            }
-          }
-        }
+              'index.ts': [],
+            },
+          },
+        },
       });
 
       const [pathAlias, path] = errorParams;
 
       expect(() =>
-        getTsConfigContext(toFsPath("/project/tsconfig.json"))
+        getTsConfigContext(toFsPath('/project/tsconfig.json')),
       ).toThrowUserError(new InvalidPathError(pathAlias, path));
     });
   }
 
-  describe("baseUrl", () => {
-    it("should be undefined if not set", () => {
+  describe('baseUrl', () => {
+    it('should be undefined if not set', () => {
       createProject({
-        "tsconfig.json": tsConfig({}),
-        "main.ts": []
+        'tsconfig.json': tsConfig({}),
+        'main.ts': [],
       });
 
-      const context = getTsConfigContext(toFsPath("/project/tsconfig.json"));
+      const context = getTsConfigContext(toFsPath('/project/tsconfig.json'));
 
       expect(context.baseUrl).toBeUndefined();
     });
 
-    it("should provide the FsPath if set", () => {
+    it('should provide the FsPath if set', () => {
       createProject({
-        "tsconfig.json": tsConfig({
-          baseUrl: "."
+        'tsconfig.json': tsConfig({
+          baseUrl: '.',
         }),
-        "main.ts": []
+        'main.ts': [],
       });
 
-      const context = getTsConfigContext(toFsPath("/project/tsconfig.json"));
+      const context = getTsConfigContext(toFsPath('/project/tsconfig.json'));
 
       expect(context.baseUrl).toBe('/project');
     });
 
-    it("should be inferred from a parent if not available", () => {
+    it('should be inferred from a parent if not available', () => {
       createProject({
-        "tsconfig.base.json": tsConfig({
-          baseUrl: "app/src"
+        'tsconfig.base.json': tsConfig({
+          baseUrl: 'app/src',
         }),
         app: {
           src: {
-            "tsconfig.json": fullTsConfig({
-              extends: "../../tsconfig.base.json"
+            'tsconfig.json': fullTsConfig({
+              extends: '../../tsconfig.base.json',
             }),
-            "main.ts": []
-          }
-        }
+            'main.ts': [],
+          },
+        },
       });
 
-      const context = getTsConfigContext(toFsPath("/project/app/src/tsconfig.json"));
+      const context = getTsConfigContext(
+        toFsPath('/project/app/src/tsconfig.json'),
+      );
 
       expect(context.baseUrl).toBe('/project/app/src');
-    })
+    });
 
-    it("should override parent", () => {
+    it('should override parent', () => {
       createProject({
-        "tsconfig.base.json": tsConfig({
-          baseUrl: "."
+        'tsconfig.base.json': tsConfig({
+          baseUrl: '.',
         }),
         app: {
-          "tsconfig.json": fullTsConfig({
-            extends: "../tsconfig.base.json",
+          'tsconfig.json': fullTsConfig({
+            extends: '../tsconfig.base.json',
             compilerOptions: {
-              baseUrl: "."
-            }
+              baseUrl: '.',
+            },
           }),
           src: {
-            "main.ts": []
-          }
-        }
+            'main.ts': [],
+          },
+        },
       });
 
-      const context = getTsConfigContext(toFsPath("/project/app/tsconfig.json"));
+      const context = getTsConfigContext(
+        toFsPath('/project/app/tsconfig.json'),
+      );
 
       expect(context.baseUrl).toBe('/project/app');
     });
 
-
     it(`should consider the baseUrl's value for path resolution`, () => {
       createProject({
-        "tsconfig.json": tsConfig({
-          paths: { "@app/*": ["app"] },
-          baseUrl: "./src"
+        'tsconfig.json': tsConfig({
+          paths: { '@app/*': ['app'] },
+          baseUrl: './src',
         }),
         src: {
           app: {
-            "main.ts": [],
+            'main.ts': [],
             customers: {
-              "index.ts": []
+              'index.ts': [],
             },
             holidays: {
-              "index.ts": []
-            }
-          }
-        }
+              'index.ts': [],
+            },
+          },
+        },
       });
 
       expect(
-        getTsConfigContext(toFsPath("/project/tsconfig.json")).paths
-      ).toEqual({ "@app/*": "/project/src/app" });
+        getTsConfigContext(toFsPath('/project/tsconfig.json')).paths,
+      ).toEqual({ '@app/*': '/project/src/app' });
     });
 
-    it("should have nested paths with different baseUrls", () => {
+    it('should have nested paths with different baseUrls', () => {
       createProject({
-        "tsconfig.base.json": tsConfig({
-          paths: { "@root/*": ["."] },
+        'tsconfig.base.json': tsConfig({
+          paths: { '@root/*': ['.'] },
         }),
         app: {
-          "tsconfig.sub-base.json": fullTsConfig({
-            extends: "../tsconfig.base.json",
+          'tsconfig.sub-base.json': fullTsConfig({
+            extends: '../tsconfig.base.json',
             compilerOptions: {
-              baseUrl: "./src",
-              paths: { "@app/*": ["."] }
-            }
+              baseUrl: './src',
+              paths: { '@app/*': ['.'] },
+            },
           }),
           src: {
-            "tsconfig.json": fullTsConfig({
-              extends: "../tsconfig.sub-base.json",
+            'tsconfig.json': fullTsConfig({
+              extends: '../tsconfig.sub-base.json',
               compilerOptions: {
-                baseUrl: ".",
-                paths: { "@customers/*": ["customers"] }
-              }
+                baseUrl: '.',
+                paths: { '@customers/*': ['customers'] },
+              },
             }),
-            "main.ts": ['@customers'],
+            'main.ts': ['@customers'],
             customers: {
-              "index.ts": []
+              'index.ts': [],
             },
-          }
-        }
+          },
+        },
       });
 
-      const context = getTsConfigContext(toFsPath("/project/app/src/tsconfig.json"));
+      const context = getTsConfigContext(
+        toFsPath('/project/app/src/tsconfig.json'),
+      );
 
       expect(context.baseUrl).toBe('/project/app/src');
       expect(context.paths).toEqual({
-        "@root/*": "/project",
-        "@app/*": "/project/app/src",
-        "@customers/*": "/project/app/src/customers"
+        '@root/*': '/project',
+        '@app/*': '/project/app/src',
+        '@customers/*': '/project/app/src/customers',
       });
     });
   });
 
-  test("no compilerOptions", () => {
+  describe('extends and alias', () => {
+    it('should support aliases', () => {
+      createProject({
+        tsconfigs: {
+          'tsconfig.vue.json': tsConfig({
+            baseUrl: '../vue',
+            paths: { '@vue/*': ['../app/src'] },
+          }),
+        },
+        app: {
+          src: {
+            'tsconfig.json': fullTsConfig({
+              extends: '@configs/tsconfig.vue.json',
+              compilerOptions: {
+                baseUrl: '.',
+                paths: { '@configs/*': ['../../tsconfigs'] },
+              },
+            }),
+            'main.ts': ['./customer'],
+            customers: {
+              'index.ts': [],
+            },
+          },
+        },
+      });
+
+      const context = getTsConfigContext(
+        toFsPath('/project/app/src/tsconfig.json'),
+      );
+
+      expect(context.baseUrl).toBe('/project/app/src');
+      expect(context.paths).toEqual({
+        '@configs/*': '/project/tsconfigs',
+        '@vue/*': '/project/app/src',
+      });
+    });
+
+    it('should support support also a non-wildcard alias', () => {
+      createProject({
+        tsconfigs: {
+          'tsconfig.vue.json': tsConfig({
+            baseUrl: '../vue',
+            paths: { '@vue/*': ['../app/src'] },
+          }),
+        },
+        app: {
+          src: {
+            'tsconfig.json': fullTsConfig({
+              extends: '@config',
+              compilerOptions: {
+                baseUrl: '.',
+                paths: { '@config': ['../../tsconfigs/tsconfig.vue.json'] },
+              },
+            }),
+            'main.ts': ['./customer'],
+            customers: {
+              'index.ts': [],
+            },
+          },
+        },
+      });
+
+      const context = getTsConfigContext(
+        toFsPath('/project/app/src/tsconfig.json'),
+      );
+
+      expect(context.baseUrl).toBe('/project/app/src');
+      expect(context.paths).toEqual({
+        '@config': '/project/tsconfigs/tsconfig.vue.json',
+        '@vue/*': '/project/app/src',
+      });
+    });
+
+    it('should throw SH-010, if extends cannot be resolved', () => {
+      createProject({
+        tsconfigs: {
+          'tsconfig.angular.json': tsConfig(),
+        },
+        app: {
+          src: {
+            'tsconfig.json': fullTsConfig({
+              extends: '@configs/tsconfig.vue.json',
+              compilerOptions: {
+                baseUrl: '.',
+                paths: { '@configs/**': ['../../tsconfigs'] },
+              },
+            }),
+          },
+        },
+      });
+
+      expect(() =>
+        getTsConfigContext(toFsPath('/project/app/src/tsconfig.json')),
+      ).toThrowUserError(
+        new TsExtendsResolutionError(
+          '/project/app/src/tsconfig.json',
+          '@configs/tsconfig.vue.json',
+        ),
+      );
+    });
+  });
+
+  test('no compilerOptions', () => {
     createProject({
-      "tsconfig.json": JSON.stringify({}),
+      'tsconfig.json': JSON.stringify({}),
       src: {
         app: {
-          "main.ts": []
-        }
-      }
+          'main.ts': [],
+        },
+      },
     });
 
     expect(
-      getTsConfigContext(toFsPath("/project/tsconfig.json")).rootDir
-    ).toEqual("/project");
+      getTsConfigContext(toFsPath('/project/tsconfig.json')).rootDir,
+    ).toEqual('/project');
   });
 });

--- a/packages/core/src/lib/file-info/tests/resolve-potential-ts-path.spec.ts
+++ b/packages/core/src/lib/file-info/tests/resolve-potential-ts-path.spec.ts
@@ -1,0 +1,20 @@
+import { ResolveFn } from '../traverse-filesystem';
+import { resolvePotentialTsPath } from '../resolve-potential-ts-path';
+import { FsPath } from '../fs-path';
+import { it, expect } from 'vitest';
+
+it('should return undefined if TS resolving does not work', () => {
+  const resolveFn: ResolveFn = () => ({
+    resolvedModule: undefined,
+  });
+
+  expect(
+    resolvePotentialTsPath(
+      '@customers',
+      {
+        '@customers': '/project/src/app/customers/index.ts' as FsPath,
+      },
+      resolveFn,
+    ),
+  ).toBeUndefined();
+});

--- a/packages/core/src/lib/file-info/tests/traverse-filesystem.spec.ts
+++ b/packages/core/src/lib/file-info/tests/traverse-filesystem.spec.ts
@@ -4,11 +4,7 @@ import { generateTsData } from '../generate-ts-data';
 import { FsPath, toFsPath } from '../fs-path';
 import { UnassignedFileInfo } from '../unassigned-file-info';
 import { tsConfig } from '../../test/fixtures/ts-config';
-import {
-  ResolveFn,
-  resolvePotentialTsPath,
-  traverseFilesystem,
-} from '../traverse-filesystem';
+import { traverseFilesystem } from '../traverse-filesystem';
 import { describe, it, expect } from 'vitest';
 import { buildFileInfo } from '../../test/build-file-info';
 import getFs from '../../fs/getFs';
@@ -210,23 +206,6 @@ describe('traverse filesystem', () => {
     });
   });
 
-  it('should return undefined if TS resolving does not work', () => {
-    const resolveFn: ResolveFn = () => ({
-      resolvedModule: undefined,
-    });
-
-    expect(
-      resolvePotentialTsPath(
-        '@customers',
-        {
-          '@customers': '/project/src/app/customers/index.ts' as FsPath,
-        },
-        resolveFn,
-        'home.component.ts',
-      ),
-    ).toBeUndefined();
-  });
-
   describe('external libraries', () => {
     it('should add external libraries', () => {
       const fileInfo = setup({
@@ -383,8 +362,12 @@ describe('traverse filesystem', () => {
     const tsData = generateTsData(toFsPath('/project/tsconfig.json'));
     const mainPath = toFsPath('/project/src/app/app.component.ts');
 
-    const unassignedFileInfo = traverseFilesystem(mainPath, new Map<FsPath, UnassignedFileInfo>(), tsData);
+    const unassignedFileInfo = traverseFilesystem(
+      mainPath,
+      new Map<FsPath, UnassignedFileInfo>(),
+      tsData,
+    );
 
-    expect(unassignedFileInfo.imports).toHaveLength(1)
+    expect(unassignedFileInfo.imports).toHaveLength(1);
   });
 });

--- a/packages/core/src/lib/file-info/traverse-filesystem.ts
+++ b/packages/core/src/lib/file-info/traverse-filesystem.ts
@@ -1,8 +1,10 @@
 import { UnassignedFileInfo } from './unassigned-file-info';
 import getFs from '../fs/getFs';
 import * as ts from 'typescript';
-import { TsData, TsPaths } from './ts-data';
-import { FsPath, isFsPath, toFsPath } from './fs-path';
+import { TsData } from './ts-data';
+import { FsPath } from './fs-path';
+import { resolvePotentialTsPath } from './resolve-potential-ts-path';
+import { fixPathSeparators } from './fix-path-separators';
 
 export type ResolveFn = (
   moduleName: string,
@@ -64,7 +66,10 @@ export function traverseFilesystem(
 
     if (resolvedTsPath) {
       importPath = resolvedTsPath;
-    } else if (resolvedImport.resolvedModule) {
+    }
+
+    // check if external library or normal file
+    else if (resolvedImport.resolvedModule) {
       const { resolvedFileName } = resolvedImport.resolvedModule;
       if (!resolvedImport.resolvedModule.isExternalLibraryImport) {
         importPath = fixPathSeparators(resolvedFileName);
@@ -99,88 +104,4 @@ export function traverseFilesystem(
   }
 
   return fileInfo;
-}
-
-export function resolvePotentialTsPath(
-  moduleName: string,
-  tsPaths: TsPaths,
-  resolveFn: ResolveFn,
-): FsPath | undefined {
-  let unpathedImport: string | undefined;
-  for (const tsPath in tsPaths) {
-    const { isWildcard, clearedTsPath } = clearTsPath(tsPath);
-    // import from '@app/app.component' & paths: {'@app/*': ['src/app/*']}
-    if (isWildcard && moduleName.startsWith(clearedTsPath)) {
-      const pathMapping = tsPaths[tsPath];
-      unpathedImport = moduleName.replace(clearedTsPath, pathMapping);
-    }
-    // import from '@app' & paths: { '@app': [''] }
-    else if (tsPath === moduleName) {
-      unpathedImport = tsPaths[tsPath];
-    }
-
-    // current path applies -> resolve it
-    if (unpathedImport) {
-      // path is file -> return as is
-      if (isPathFile(unpathedImport)) {
-        return fixPathSeparators(toFsPath(unpathedImport));
-      }
-      // path is directory or something else -> rely on TypeScript resolvers
-      else {
-        const resolvedImport = resolveFn(unpathedImport);
-        // if path applies but import is for external library with same time,
-        // we need to rely on the native TypeScript resolver, which is done
-        // outside the path resolving.
-        if (resolvedImport.resolvedModule) {
-          return toFsPath(
-            fixPathSeparators(resolvedImport.resolvedModule.resolvedFileName),
-          );
-        }
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function clearTsPath(tsPath: string) {
-  const [isWildcard, clearedPath] = tsPath.endsWith('/*')
-    ? [true, tsPath.slice(0, -2)]
-    : [false, tsPath];
-  return { isWildcard, clearedTsPath: clearedPath };
-}
-
-/**
- * Ensures that `FsPath` uses the separator from the OS and not always '/'
- *
- * @param path
- */
-function fixPathSeparators(path: string): FsPath {
-  const fs = getFs();
-
-  if (fs.pathSeparator !== '/') {
-    return toFsPath(path.replace(/\//g, fs.pathSeparator));
-  }
-
-  return toFsPath(path);
-}
-
-/**
- * Checks if the path is a file.
- *
- * For example in tsconfig.json:
- * ```json
- *   "paths": {
- *     "@app": ["src/app/index"]
- *   }
- * ```
- *
- * 'src/app/index' comes already as absolute path with ts extension from
- * pre-processing of @generateTsData.
- *
- * @param path '/.../src/app/index.ts' according to the example above
- */
-function isPathFile(path: string): boolean {
-  const fs = getFs();
-  return fs.exists(path) && isFsPath(path) && fs.isFile(path);
 }


### PR DESCRIPTION
The `extends` property in `tsconfig.json` now properly resolves aliases defined in the `paths` configuration.

Fixes #177