### PR TITLE
Remove .json and .html from root eslint included files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-// @ts-check
+/* eslint-disable @typescript-eslint/no-require-imports */
 const tseslint = require('typescript-eslint');
 const prettierRecommended = require('eslint-plugin-prettier/recommended');
 const unusedImports = require('eslint-plugin-unused-imports');
@@ -6,7 +6,7 @@ const unusedImports = require('eslint-plugin-unused-imports');
 module.exports = tseslint.config(
   ...tseslint.configs.recommended,
   {
-    files: ['*.json', '*.html', '*.ts'],
+    files: ['*.ts'],
     extends: [prettierRecommended],
   },
   {


### PR DESCRIPTION
This is a simple PR to address https://github.com/softarc-consulting/sheriff/issues/172

I wish now I'd added it as a comment to the [current branch](https://github.com/softarc-consulting/sheriff/pull/179) I'm working on rather than creating a separate issue of it. It's not that big a deal either way.

This PR stops eslint from red-underlining `package.json` in the root of the repo - and other `.json` files that can become hard to red with red underlines.