### PR TITLE
Feat/json export violations

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,4 @@ export { noDependencies } from './lib/checks/no-dependencies';
 export { UserSheriffConfig as SheriffConfig } from './lib/config/user-sheriff-config';
 export { UserError } from './lib/error/user-error';
 export { getProjectData } from './lib/api/get-project-data';
+export { SheriffViolations } from './lib/cli/sheriff-violations';

--- a/packages/core/src/lib/cli/internal/reporter/get-reporter.ts
+++ b/packages/core/src/lib/cli/internal/reporter/get-reporter.ts
@@ -1,0 +1,9 @@
+import { JsonReporter } from './json-reporter';
+
+export function getReporter(reporterFormat: string) {
+  if (reporterFormat === 'json') {
+    return new JsonReporter();
+  }
+
+  return null;
+}

--- a/packages/core/src/lib/cli/internal/reporter/json-reporter.ts
+++ b/packages/core/src/lib/cli/internal/reporter/json-reporter.ts
@@ -1,0 +1,29 @@
+import { Reporter } from './reporter';
+import { cli } from '../../cli';
+import getFs from '../../../fs/getFs';
+
+import { SheriffViolations } from '../../sheriff-violations';
+
+export class JsonReporter implements Reporter {
+  createReport(args: {
+    exportDir: string;
+    projectName: string;
+    validationResults: SheriffViolations;
+  }): void {
+    const fs = getFs();
+    const targetPath = fs.join(
+      args.exportDir,
+      args.projectName,
+      'sheriff-report' + this.#getReportExtension(),
+    );
+    cli.log(`Creating .json-export`);
+
+    fs.createDir(fs.join(args.exportDir, args.projectName!));
+
+    fs.writeFile(targetPath, JSON.stringify(args.validationResults, null, 2));
+  }
+
+  #getReportExtension(): string {
+    return '.json';
+  }
+}

--- a/packages/core/src/lib/cli/internal/reporter/reporter.ts
+++ b/packages/core/src/lib/cli/internal/reporter/reporter.ts
@@ -1,0 +1,9 @@
+import { SheriffViolations } from '../../sheriff-violations';
+
+export interface Reporter {
+  createReport(args: {
+    exportDir: string;
+    projectName: string;
+    validationResults: SheriffViolations;
+  }): void;
+}

--- a/packages/core/src/lib/cli/sheriff-violations.ts
+++ b/packages/core/src/lib/cli/sheriff-violations.ts
@@ -1,0 +1,8 @@
+import { DependencyRuleViolation } from '../checks/check-for-dependency-rule-violation';
+
+export type SheriffViolations = {
+  encapsulationsCount: number;
+  encapsulationValidations: string[];
+  dependencyRuleViolationsCount: number;
+  dependencyRuleViolations: DependencyRuleViolation[];
+};

--- a/packages/core/src/lib/cli/tests/__snapshots__/json-reporter.spec.ts.snap
+++ b/packages/core/src/lib/cli/tests/__snapshots__/json-reporter.spec.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`json reporter > should create a json-file in /.sheriff/project/sheriff-report.json 1`] = `
+"{
+  "encapsulationsCount": 0,
+  "encapsulationValidations": [],
+  "dependencyRuleViolationsCount": 2,
+  "dependencyRuleViolations": [
+    {
+      "rawImport": "@eternal/shared/master-data",
+      "fromModulePath": "/project/customers/feature",
+      "toModulePath": "/project/shared/master-data",
+      "fromTag": "domain:customers",
+      "toTags": [
+        "shared:master-data"
+      ]
+    },
+    {
+      "rawImport": "@eternal/shared/form",
+      "fromModulePath": "/project/customers/ui",
+      "toModulePath": "/project/app/shared/form",
+      "fromTag": "domain:customers",
+      "toTags": [
+        "shared:form"
+      ]
+    }
+  ]
+}"
+`;

--- a/packages/core/src/lib/cli/tests/json-reporter.spec.ts
+++ b/packages/core/src/lib/cli/tests/json-reporter.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, it, vitest, expect, beforeAll } from 'vitest';
+import { VirtualFs } from '../../fs/virtual-fs';
+import getFs, { useVirtualFs } from '../../fs/getFs';
+import { JsonReporter } from '../internal/reporter/json-reporter';
+import { toFsPath } from '../../file-info/fs-path';
+
+import { SheriffViolations } from '../sheriff-violations';
+
+describe('json reporter', () => {
+  let fs: VirtualFs;
+  beforeAll(() => {
+    useVirtualFs();
+    fs = getFs() as VirtualFs;
+  });
+
+  beforeEach(() => {
+    fs.reset();
+    fs.createDir('/project/customers/feature');
+    fs.createDir('/project/shared/master-data');
+    fs.createDir('/project/customers/ui');
+    fs.createDir('/project/app/shared/form');
+  });
+  it('should create a json-file in /.sheriff/project/sheriff-report.json', () => {
+    const reporter = new JsonReporter();
+    const violations: SheriffViolations = {
+      encapsulationsCount: 0,
+      encapsulationValidations: [],
+      dependencyRuleViolationsCount: 2,
+      dependencyRuleViolations: [
+        {
+          rawImport: '@eternal/shared/master-data',
+          fromModulePath: toFsPath('/project/customers/feature'),
+          toModulePath: toFsPath('/project/shared/master-data'),
+          fromTag: 'domain:customers',
+          toTags: ['shared:master-data'],
+        },
+        {
+          rawImport: '@eternal/shared/form',
+          fromModulePath: toFsPath('/project/customers/ui'),
+          toModulePath: toFsPath('/project/app/shared/form'),
+          fromTag: 'domain:customers',
+          toTags: ['shared:form'],
+        },
+      ],
+    };
+    reporter.createReport({
+      exportDir: '.sheriff',
+      projectName: 'project',
+      validationResults: violations,
+    });
+
+    expect(
+      fs.readFile('.sheriff/project/sheriff-report.json'),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/core/src/lib/config/default-config.ts
+++ b/packages/core/src/lib/config/default-config.ts
@@ -11,5 +11,6 @@ export const defaultConfig: Configuration = {
   log: false,
   entryFile: '',
   isConfigFileMissing: false,
-  barrelFileName: 'index.ts'
+  barrelFileName: 'index.ts',
+  exportDir: '.sheriff',
 };

--- a/packages/core/src/lib/config/user-sheriff-config.ts
+++ b/packages/core/src/lib/config/user-sheriff-config.ts
@@ -220,12 +220,12 @@ export interface UserSheriffConfig {
    *
    * ---
    */
-  encapsulationPattern?: string | RegExp
+  encapsulationPattern?: string | RegExp;
 
   /**
    * @deprecated no warning is shown.
    */
-  showWarningOnBarrelCollision?: boolean
+  showWarningOnBarrelCollision?: boolean;
 
   /**
    * enable internal logging and save it to `sheriff.log`
@@ -236,4 +236,11 @@ export interface UserSheriffConfig {
    * The file that the CLI should use by default.
    */
   entryFile?: string;
+
+  /**
+   * The directory where the Sheriff CLI should export the results.
+   *
+   * Default is ./sheriff
+   */
+  exportDir?: string;
 }


### PR DESCRIPTION
# Enhancing the CLI with a `reporter` argument to create reports/exports

**todo**

- [ ] handle correctly multi workspace projects. See 1) for more context
- [ ] Agree on `fromModulePath` / `toModulePath`. See 2) for more context
- [ ] JUnit reporter. See 3). 
- [ ] comprehensive tests
- [ ] agree on the final shape of data which should be exported
- [ ] Make name of report customizable. Currently it is hard coded to `sheriff-report`
- [ ] Final clean up 


**more context**
1 )
 Currently we create the reports in `/.sheriff/{root}/sheriff-result.json`
This approach does not work for workspaces with multiple projects as the report will just be overridden. 

We need to correctly derive the project name. Here we need to consider how to do it for Angular workspaces with multiple projects and for nx monorepos. 

As Sheriff is framework-agnostic we also need to think about how to do it for others as well.

From a DX-perspective it would be great if we can derive it somehow in the background. However I think this will be quite hard. 

Straight forward solution with less DX would be another CLI argument `--projectName`.

2 ) 
In the `toModulePath` and `fromModulePath` we do have the full path right now, like: `/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/customers/feature`

Do we want to keep it like this or do we want to have the relative path from the root which would be in this case `/test-projects/angular-iv/src/app/customers/feature`?

Imho the relative path from the project root makes more sense.

3 ) 
The JUnit report will look something like this
```xml

<testsuite name="Sheriff">
  <testcase classname="src/utils.ts" name="encapsulation" line="12">
    <failure message=".src/utils.ts cannot be imported. It is encapsulated."/>
  </testcase>
  <testcase classname="src/utils.ts" name="deep-import" line="12">
    <failure message=".src/utils.ts is a deep import from a barrel module. Use the module's barrel file (index.ts) instead."/>
  </testcase>
  <testcase classname="src/components/button.ts" name="dependency-rule" line="5">
    <failure message="module /src/components cannot access /src/shared/ui. Tag domain:components has no clearance for tags shared"/>
  </testcase>
</testsuite>
```

## Current State
When running `sheriff verify src/main.ts --reporter=json` we will now create a json-report which will look something like this:

```json
{
  "encapsulationsCount": 0,
  "encapsulationValidations": [],
  "dependencyRuleViolationsCount": 0,
  "dependencyRuleViolations": [
    {
      "rawImport": "@eternal/shared/master-data",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/customers/feature",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/master-data",
      "fromTag": "domain:customers",
      "toTags": [
        "shared:master-data"
      ]
    },
    {
      "rawImport": "@eternal/shared/form",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/customers/ui",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/form",
      "fromTag": "domain:customers",
      "toTags": [
        "shared:form"
      ]
    },
    {
      "rawImport": "@eternal/shared/form",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/customers/ui",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/form",
      "fromTag": "domain:customers",
      "toTags": [
        "shared:form"
      ]
    },
    {
      "rawImport": "@eternal/shared/ui-messaging",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/customers/data",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/ui-messaging",
      "fromTag": "domain:customers",
      "toTags": [
        "shared:ui-messaging"
      ]
    },
    {
      "rawImport": "@eternal/shared/form",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/customers/feature",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/form",
      "fromTag": "domain:customers",
      "toTags": [
        "shared:form"
      ]
    },
    {
      "rawImport": "@eternal/shared/master-data",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/customers/feature",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/master-data",
      "fromTag": "domain:customers",
      "toTags": [
        "shared:master-data"
      ]
    },
    {
      "rawImport": "@eternal/shared/ngrx-utils",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/bookings",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/ngrx-utils",
      "fromTag": "domain:bookings",
      "toTags": [
        "shared:ngrx-utils"
      ]
    },
    {
      "rawImport": "@eternal/shared/config",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/holidays/feature",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/config",
      "fromTag": "domain:holidays",
      "toTags": [
        "shared:config"
      ]
    },
    {
      "rawImport": "@eternal/shared/ui",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/holidays/ui",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/ui",
      "fromTag": "domain:holidays",
      "toTags": [
        "shared:ui"
      ]
    },
    {
      "rawImport": "@eternal/shared/util",
      "fromModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/holidays/feature",
      "toModulePath": "/Users/michaelberger/Documents/dev/open-source/sheriff-fork/test-projects/angular-iv/src/app/shared/util",
      "fromTag": "domain:holidays",
      "toTags": [
        "shared:util"
      ]
    }
  ]
}

```

