### PR TITLE
fix(eslint-plugin): eslint rules not found

### DIFF
--- a/packages/eslint-plugin/src/lib/configs/all.ts
+++ b/packages/eslint-plugin/src/lib/configs/all.ts
@@ -2,7 +2,7 @@ import type { TSESLint } from '@typescript-eslint/utils';
 import rules from '../rules';
 
 const commonConfig: TSESLint.FlatConfig.Config = {
-  files: ['*.ts, *.js'],
+  files: ['**/*.ts', '**/*.js'],
   ignores: ['sheriff.config.ts'],
   languageOptions: {
     sourceType: 'module',


### PR DESCRIPTION
From what I have seen the issue #225 is caused by an incorrect file pattern which was introduced in commit #837d792


Fixes #225