### PR TITLE
feat: add `ignoreFileExtensions` option

### DIFF
--- a/packages/core/src/lib/config/configuration.ts
+++ b/packages/core/src/lib/config/configuration.ts
@@ -15,4 +15,6 @@ export type Configuration = Required<
    * We have to apply here a little hack to ensure correct validation of the config in parseConfig
    */
   entryPoints?: Record<string, string>;
+  // ignoreFileExtensions is always present (either user-specified or default)
+  ignoreFileExtensions: string[];
 };

--- a/packages/core/src/lib/config/default-config.ts
+++ b/packages/core/src/lib/config/default-config.ts
@@ -1,4 +1,5 @@
 import { Configuration } from './configuration';
+import { defaultIgnoreFileExtensions } from './default-file-extensions';
 
 export const defaultConfig: Configuration = {
   version: 1,
@@ -13,4 +14,5 @@ export const defaultConfig: Configuration = {
   isConfigFileMissing: false,
   barrelFileName: 'index.ts',
   entryPoints: undefined,
+  ignoreFileExtensions: defaultIgnoreFileExtensions,
 };

--- a/packages/core/src/lib/config/default-file-extensions.ts
+++ b/packages/core/src/lib/config/default-file-extensions.ts
@@ -1,0 +1,40 @@
+/**
+ * Default list of file extensions that Sheriff will ignore while traversing imports.
+ * Imports whose module specifier ends with any of these extensions are skipped entirely
+ * and not added to the dependency graph.
+ */
+export const defaultIgnoreFileExtensions: string[] = [
+  // images
+  'svg',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'ico',
+  // styles
+  'css',
+  'scss',
+  'sass',
+  'less',
+  // fonts
+  'woff',
+  'woff2',
+  'ttf',
+  'eot',
+  'otf',
+  // audio
+  'mp3',
+  'wav',
+  'ogg',
+  // video
+  'mp4',
+  'webm',
+  'mov',
+  // data / misc
+  'json',
+  'csv',
+  'xml',
+  'txt',
+  'md',
+];

--- a/packages/core/src/lib/config/parse-config.ts
+++ b/packages/core/src/lib/config/parse-config.ts
@@ -51,7 +51,7 @@ export const parseConfig = (configFile: FsPath): Configuration => {
     ...rest
   } = userSheriffConfig;
 
-    if (userSheriffConfig.entryFile && userSheriffConfig.entryPoints) {
+  if (userSheriffConfig.entryFile && userSheriffConfig.entryPoints) {
     throw new CollidingEntrySettings();
   }
 
@@ -61,6 +61,24 @@ export const parseConfig = (configFile: FsPath): Configuration => {
   ) {
     throw new NoEntryPointsFoundError();
   }
+  const mergedConfig = { ...defaultConfig, ...rest };
 
-  return { ...defaultConfig, ...rest };
+  const ignoreFileExtensions = getIgnoreFileExtensions(
+    mergedConfig.ignoreFileExtensions,
+  );
+
+  return {
+    ...mergedConfig,
+    ignoreFileExtensions,
+  };
 };
+
+function getIgnoreFileExtensions(
+  ignoreFileExtensions: string[] | ((defaults: string[]) => string[]),
+): string[] {
+  const extensions =
+    typeof ignoreFileExtensions === 'function'
+      ? ignoreFileExtensions(defaultConfig.ignoreFileExtensions)
+      : ignoreFileExtensions;
+  return Array.from(new Set(extensions.map((ext) => ext.toLowerCase())));
+}

--- a/packages/core/src/lib/config/user-sheriff-config.ts
+++ b/packages/core/src/lib/config/user-sheriff-config.ts
@@ -260,4 +260,24 @@ export interface UserSheriffConfig {
    * Either `entryFile` or `entryPoints` can be set, but not both.
    */
   entryPoints?: Record<string, string>;
+
+  /**
+   * List of file extensions to ignore.
+   * Can be either:
+   * - An array of strings (replaces defaults completely)
+   * - A function that receives the default extensions and returns a new list
+   *
+   * @example
+   * ```typescript
+   * // would add 'env' and 'yaml' to the defaults
+   * ignoreFileExtensions: (defaults) => [...defaults, 'env', 'yaml']
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // would override defaults as well
+   * ignoreFileExtensions: ['env', 'yaml']
+   * ```
+   */
+  ignoreFileExtensions?: string[] | ((defaults: string[]) => string[]);
 }

--- a/packages/core/src/lib/file-info/generate-unassigned-file-info.ts
+++ b/packages/core/src/lib/file-info/generate-unassigned-file-info.ts
@@ -14,20 +14,23 @@ const log = logger('core.file-info.generate-and-root-dir');
  * @param fsPath path of a file or the content as string (used by ESLint in IDE)
  * @param runOnce do not traverse the chain of imports.
  * @param tsData misc. data around TS config
+ * @param ignoreFileExtensions array of file extensions to ignore
  * @param fileContent optional file content (used by ESLint in IDE)
  */
-export const generateUnassignedFileInfo = (
+export function generateUnassignedFileInfo(
   fsPath: FsPath,
   runOnce = false,
   tsData: TsData,
+  ignoreFileExtensions: string[],
   fileContent?: string,
-): UnassignedFileInfo => {
+): UnassignedFileInfo {
   const fileInfoDict = new Map<FsPath, UnassignedFileInfo>();
 
   const fileInfo = traverseFilesystem(
     fsPath,
     fileInfoDict,
     tsData,
+    ignoreFileExtensions,
     runOnce,
     fileContent,
   );
@@ -35,4 +38,4 @@ export const generateUnassignedFileInfo = (
   log.info(formatFileInfo(fileInfo));
 
   return fileInfo;
-};
+}

--- a/packages/core/src/lib/main/parse-project.ts
+++ b/packages/core/src/lib/main/parse-project.ts
@@ -28,6 +28,7 @@ export const parseProject = (
     entryFile,
     !traverse,
     tsData,
+    config.ignoreFileExtensions,
     fileContent,
   );
   const rootDir = tsData.rootDir;
@@ -38,22 +39,13 @@ export const parseProject = (
   const getFileInfo = (path: FsPath) =>
     throwIfNull(fileInfoMap.get(path), `cannot find FileInfo for ${path}`);
 
-  const modulePaths = findModulePaths(
-    projectDirs,
-    rootDir,
-    config
-  );
+  const modulePaths = findModulePaths(projectDirs, rootDir, config);
 
-  const modules = createModules(
-    modulePaths,
-    fileInfoMap,
-    getFileInfo,
-    {
-      entryFileInfo: unassignedFileInfo,
-      rootDir,
-      barrelFile: config.barrelFileName,
-    },
-  )
+  const modules = createModules(modulePaths, fileInfoMap, getFileInfo, {
+    entryFileInfo: unassignedFileInfo,
+    rootDir,
+    barrelFile: config.barrelFileName,
+  });
   fillFileInfoMap(fileInfoMap, modules);
 
   const fileInfo = getFileInfo(unassignedFileInfo.path);


### PR DESCRIPTION
Adds the possbility to ignore files based on their extension and comes with a default of common files that should be ignored.

Fixes
- #216 
- #215 
- #159