### PR TITLE
Feat/sub barrel files

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -87,7 +87,13 @@ These options have sensible defaults and are typically only customized for speci
 
 - **Type**: `string`
 - **Default**: `'index.ts'`
-- **Description**: Name of the barrel file that exports public APIs from a module.
+- **Description**: Name of the barrel file that exports public APIs from a module. When combined with [`enableSubBarrelFileSupport`](#enablesubbarrelfilesupport), sub-barrel files following the naming convention `<barrelBaseName>.<suffix>.<ext>` are also recognized as entry points. See [Sub-Barrel Files](./module_boundaries.md#sub-barrel-files) for details.
+
+#### `enableSubBarrelFileSupport` {#enablesubbarrelfilesupport}
+
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: When enabled, sub-barrel files are recognized as valid module entry points alongside the main barrel file. Sub-barrel files follow the naming convention `<barrelBaseName>.<suffix>.<ext>`. For example, with `barrelFileName: 'public-api.ts'`, files like `public-api.routing.ts` and `public-api.bookmarks.ts` are treated as additional exposed entry points.
 
 #### `ignoreFileExtensions` {#ignorefileextensions}
 

--- a/docs/docs/module_boundaries.md
+++ b/docs/docs/module_boundaries.md
@@ -86,6 +86,19 @@ An access to the non-exported `credential.ts` causes an error.
 
 <img width="1905"src="../img/module-boundaries-barrel-invalid.png"></img>
 
+### Sub-Barrel Files
+
+Barrel modules also support **sub-barrel files** when [`enableSubBarrelFileSupport`](./configuration.md#enablesubbarrelfilesupport) is set to `true`. These are additional entry points that follow the naming convention `<barrelBaseName>.<suffix>.<ext>`.
+
+For example, if the barrel file is `public-api.ts` (configured via [`barrelFileName`](./configuration.md#barrelfilename)), the following sub-barrel files are recognized:
+
+- `public-api.routing.ts`
+- `public-api.bookmarks.ts`
+
+Sub-barrel files allow you to split the public API of a module into logically grouped subsets. Other modules can import from any of these files without triggering an encapsulation violation.
+
+Only the main barrel file defines the module boundary. Sub-barrel files act solely as additional exposed entry points.
+
 ---
 
 It is also possible to disable the automatic module detection. For more information, see [Dependency Rules](./dependency-rules.md#automatic-tagging).

--- a/packages/core/src/lib/checks/has-encapsulation-violations.ts
+++ b/packages/core/src/lib/checks/has-encapsulation-violations.ts
@@ -23,7 +23,7 @@ export function hasEncapsulationViolations(
     if (
       isSameModule(importedFileInfo, assignedFileInfo) ||
       isExcludedRootModule(rootDir, config, importedFileInfo) ||
-      accessesBarrelFileForBarrelModules(importedFileInfo) ||
+      accessesBarrelFileForBarrelModules(importedFileInfo, config.enableSubBarrelFileSupport) ||
       accessesExposedFileForBarrelLessModules(
         importedFileInfo,
         config.enableBarrelLess,
@@ -66,9 +66,13 @@ function accessesExposedFileForBarrelLessModules(
   }
 }
 
-function accessesBarrelFileForBarrelModules(fileInfo: FileInfo) {
+function accessesBarrelFileForBarrelModules(fileInfo: FileInfo, enableSubBarrelFileSupport: boolean) {
   if (!fileInfo.moduleInfo.hasBarrel) {
     return false;
+  }
+
+  if (enableSubBarrelFileSupport) {
+    return fileInfo.moduleInfo.isBarrelFile(fileInfo.path);
   }
 
   return fileInfo.moduleInfo.barrelPath === fileInfo.path;

--- a/packages/core/src/lib/checks/tests/encapsulation-with-exclude-root.spec.ts
+++ b/packages/core/src/lib/checks/tests/encapsulation-with-exclude-root.spec.ts
@@ -93,5 +93,5 @@ function getMessage(
   }
   return isImportToBarrelLess
     ? `'${importCommand}' cannot be imported. It is encapsulated.`
-    : `'${importCommand}' is a deep import from a barrel module. Use the module's barrel file (index.ts) instead.`;
+    : `'${importCommand}' is a deep import from a barrel module. Use the module's barrel file instead.`;
 }

--- a/packages/core/src/lib/checks/tests/has-encapsulation-violations.spec.ts
+++ b/packages/core/src/lib/checks/tests/has-encapsulation-violations.spec.ts
@@ -3,6 +3,7 @@ import { hasEncapsulationViolations } from '../has-encapsulation-violations';
 import { toFsPath } from '../../file-info/fs-path';
 import { testInit } from '../../test/test-init';
 import { tsConfig } from '../../test/fixtures/ts-config';
+import { sheriffConfig } from '../../test/project-configurator';
 
 describe('check encapsulation', () => {
   it('should check for deep imports', () => {
@@ -56,5 +57,149 @@ describe('check encapsulation', () => {
         Object.keys(hasEncapsulationViolations(toFsPath(`/project/${filename}`), projectInfo)),
       ).toEqual(deepImports);
     }
+  });
+
+  it('should allow imports from sub-barrel files', () => {
+    const projectInfo = testInit('src/main.ts', {
+      'tsconfig.json': tsConfig(),
+      'sheriff.config.ts': sheriffConfig({
+        barrelFileName: 'public-api.ts',
+        enableSubBarrelFileSupport: true,
+        depRules: {},
+      }),
+      src: {
+        'main.ts': [
+          './app/customers/public-api',
+          './app/customers/public-api.routing',
+          './app/customers/public-api.bookmarks',
+          './app/customers/customer.component',
+        ],
+        app: {
+          customers: {
+            'customer.component.ts': [],
+            'customer.routes.ts': ['./customer.component'],
+            'public-api.ts': ['./customer.routes'],
+            'public-api.routing.ts': ['./customer.component'],
+            'public-api.bookmarks.ts': [],
+          },
+        },
+      },
+    });
+
+    expect(
+      Object.keys(
+        hasEncapsulationViolations(
+          toFsPath('/project/src/main.ts'),
+          projectInfo,
+        ),
+      ),
+    ).toEqual(['./app/customers/customer.component']);
+  });
+
+  it('should allow sub-barrel files with default index.ts barrel name', () => {
+    const projectInfo = testInit('src/main.ts', {
+      'tsconfig.json': tsConfig(),
+      'sheriff.config.ts': sheriffConfig({
+        enableSubBarrelFileSupport: true,
+        depRules: {},
+      }),
+      src: {
+        'main.ts': [
+          './app/customers/index',
+          './app/customers/index.routing',
+          './app/customers/customer.component',
+        ],
+        app: {
+          customers: {
+            'customer.component.ts': [],
+            'index.ts': [],
+            'index.routing.ts': ['./customer.component'],
+          },
+        },
+      },
+    });
+
+    expect(
+      Object.keys(
+        hasEncapsulationViolations(
+          toFsPath('/project/src/main.ts'),
+          projectInfo,
+        ),
+      ),
+    ).toEqual(['./app/customers/customer.component']);
+  });
+
+  it('should treat sub-barrel files as violations when enableSubBarrelFileSupport is false', () => {
+    const projectInfo = testInit('src/main.ts', {
+      'tsconfig.json': tsConfig(),
+      'sheriff.config.ts': sheriffConfig({
+        barrelFileName: 'public-api.ts',
+        enableSubBarrelFileSupport: false,
+        depRules: {},
+      }),
+      src: {
+        'main.ts': [
+          './app/customers/public-api',
+          './app/customers/public-api.routing',
+          './app/customers/public-api.bookmarks',
+        ],
+        app: {
+          customers: {
+            'public-api.ts': [],
+            'public-api.routing.ts': [],
+            'public-api.bookmarks.ts': [],
+          },
+        },
+      },
+    });
+
+    expect(
+      Object.keys(
+        hasEncapsulationViolations(
+          toFsPath('/project/src/main.ts'),
+          projectInfo,
+        ),
+      ),
+    ).toEqual([
+      './app/customers/public-api.routing',
+      './app/customers/public-api.bookmarks',
+    ]);
+  });
+
+  it('should not break barrel-less modules when enableSubBarrelFileSupport is true', () => {
+    const projectInfo = testInit('src/main.ts', {
+      'tsconfig.json': tsConfig(),
+      'sheriff.config.ts': sheriffConfig({
+        modules: {
+          'src/app/<domain>': '<domain>',
+        },
+        depRules: {},
+        enableBarrelLess: true,
+        enableSubBarrelFileSupport: true,
+      }),
+      src: {
+        'main.ts': [
+          './app/customers/customer.component',
+          './app/customers/internal/hidden.service',
+        ],
+        app: {
+          customers: {
+            'customer.component.ts': [],
+            internal: {
+              'hidden.service.ts': [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      Object.keys(
+        hasEncapsulationViolations(
+          toFsPath('/project/src/main.ts'),
+          projectInfo,
+        ),
+      ),
+    ).toEqual(['./app/customers/internal/hidden.service']);
   });
 });

--- a/packages/core/src/lib/config/default-config.ts
+++ b/packages/core/src/lib/config/default-config.ts
@@ -13,6 +13,7 @@ export const defaultConfig: Configuration = {
   entryFile: '',
   isConfigFileMissing: false,
   barrelFileName: 'index.ts',
+  enableSubBarrelFileSupport: false,
   entryPoints: undefined,
   ignoreFileExtensions: defaultIgnoreFileExtensions,
 };

--- a/packages/core/src/lib/config/tests/parse-config.spec.ts
+++ b/packages/core/src/lib/config/tests/parse-config.spec.ts
@@ -40,6 +40,7 @@ describe('parse Config', () => {
       'entryFile',
       'isConfigFileMissing',
       'barrelFileName',
+      'enableSubBarrelFileSupport',
       'entryPoints',
       'ignoreFileExtensions',
     ]);
@@ -83,6 +84,7 @@ export const config: SheriffConfig = {
         isConfigFileMissing: false,
         entryFile: '',
         barrelFileName: 'index.ts',
+        enableSubBarrelFileSupport: false,
         entryPoints: undefined,
         ignoreFileExtensions: defaultIgnoreFileExtensions,
       });

--- a/packages/core/src/lib/config/user-sheriff-config.ts
+++ b/packages/core/src/lib/config/user-sheriff-config.ts
@@ -166,6 +166,18 @@ export interface UserSheriffConfig {
   barrelFileName?: string;
 
   /**
+   * When enabled, sub-barrel files are recognized as valid module
+   * entry points alongside the main barrel file.
+   *
+   * Sub-barrel files follow the naming convention `<barrelBaseName>.<suffix>.<ext>`.
+   * For example, if the barrel file is `public-api.ts`, then `public-api.routing.ts`
+   * and `public-api.bookmarks.ts` are valid sub-barrel files.
+   *
+   * Defaults to `false`.
+   */
+  enableSubBarrelFileSupport?: boolean;
+
+  /**
    * The barrel-less approach means that the module
    * does not have an `index.ts` file. Instead, all files
    * are directly available, except those which are located

--- a/packages/core/src/lib/eslint/tests/violates-encapsulation-rule.spec.ts
+++ b/packages/core/src/lib/eslint/tests/violates-encapsulation-rule.spec.ts
@@ -156,7 +156,7 @@ describe('encapsulation', () => {
       false,
     );
     expect(message).toBe(
-      `'./customers/customer.component' is a deep import from a barrel module. Use the module's barrel file (index.ts) instead.`,
+      `'./customers/customer.component' is a deep import from a barrel module. Use the module's barrel file instead.`,
     );
   });
 });

--- a/packages/core/src/lib/eslint/violates-encapsulation-rule.ts
+++ b/packages/core/src/lib/eslint/violates-encapsulation-rule.ts
@@ -6,6 +6,7 @@ import { isRelativeImport } from './is-relative-import';
 
 let cache: Record<string, FileInfo> = {};
 let cachedFileInfo: FileInfo | undefined;
+let cachedEnableSubBarrelFileSupport = false;
 
 /**
  * This is the adapter for the ESLint plugin
@@ -36,6 +37,7 @@ export const violatesEncapsulationRule = (
   if (isFirstRun) {
     cache = {};
     cachedFileInfo = undefined;
+    cachedEnableSubBarrelFileSupport = false;
   }
 
   if (!cachedFileInfo) {
@@ -46,6 +48,7 @@ export const violatesEncapsulationRule = (
     });
 
     cachedFileInfo = projectInfo.fileInfo;
+    cachedEnableSubBarrelFileSupport = projectInfo.config.enableSubBarrelFileSupport;
     cache = hasEncapsulationViolations(fsPath, projectInfo);
   }
 
@@ -65,8 +68,12 @@ export const violatesEncapsulationRule = (
     return "Deep import is not allowed. Use the module's index.ts or path.";
   } else {
     const importFileInfo = cache[importCommand];
-    return importFileInfo.moduleInfo.hasBarrel
-      ? `'${importCommand}' is a deep import from a barrel module. Use the module's barrel file (index.ts) instead.`
-      :  `'${importCommand}' cannot be imported. It is encapsulated.`;
+    if (!importFileInfo.moduleInfo.hasBarrel) {
+      return `'${importCommand}' cannot be imported. It is encapsulated.`;
+    }
+
+    return cachedEnableSubBarrelFileSupport
+      ? `'${importCommand}' is a deep import from a barrel module. Use the module's barrel file or a sub-barrel file instead.`
+      : `'${importCommand}' is a deep import from a barrel module. Use the module's barrel file instead.`;
   }
 };

--- a/packages/core/src/lib/modules/module.ts
+++ b/packages/core/src/lib/modules/module.ts
@@ -10,6 +10,8 @@ import getFs from '../fs/getFs';
  */
 export class Module {
   readonly fileInfos: FileInfo[] = [];
+  private readonly barrelPrefix: string;
+  private readonly barrelExt: string;
 
   constructor(
     public readonly path: FsPath,
@@ -19,6 +21,9 @@ export class Module {
     public readonly hasBarrel: boolean,
     private readonly barrelFile: string,
   ) {
+    const dotIndex = barrelFile.lastIndexOf('.');
+    this.barrelPrefix = dotIndex !== -1 ? barrelFile.slice(0, dotIndex + 1) : '';
+    this.barrelExt = dotIndex !== -1 ? barrelFile.slice(dotIndex) : '';
   }
 
   addFileInfo(unassignedFileInfo: UnassignedFileInfo) {
@@ -29,5 +34,42 @@ export class Module {
 
   get barrelPath(): FsPath {
     return toFsPath(getFs().join(this.path, this.barrelFile));
+  }
+
+  /**
+   * Checks if the given file path is the main barrel file or a sub-barrel
+   * file of this module.
+   *
+   * Sub-barrel files follow the naming convention `<barrelBaseName>.<suffix>.<ext>`.
+   * For example, if the barrel file is `public-api.ts`, then `public-api.routing.ts`
+   * and `public-api.bookmarks.ts` are sub-barrel files.
+   *
+   * Uses only string operations for performance — no filesystem or path API calls.
+   */
+  isBarrelFile(filePath: FsPath): boolean {
+    if (!filePath.startsWith(this.path)) {
+      return false;
+    }
+
+    const sepChar = filePath.charAt(this.path.length);
+    if (sepChar !== '/' && sepChar !== '\\') {
+      return false;
+    }
+
+    const fileName = filePath.slice(this.path.length + 1);
+
+    if (fileName.includes('/') || fileName.includes('\\')) {
+      return false;
+    }
+
+    if (fileName === this.barrelFile) {
+      return true;
+    }
+
+    return (
+      this.barrelPrefix !== '' &&
+      fileName.startsWith(this.barrelPrefix) &&
+      fileName.endsWith(this.barrelExt)
+    );
   }
 }

--- a/packages/core/src/lib/modules/tests/module-is-barrel-file.spec.ts
+++ b/packages/core/src/lib/modules/tests/module-is-barrel-file.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { Module } from '../module';
+import { FsPath, toFsPath } from '../../file-info/fs-path';
+import { FileInfo } from '../file.info';
+import getFs, { useVirtualFs } from '../../fs/getFs';
+
+describe('Module.isBarrelFile', () => {
+  const fileInfoMap = new Map<FsPath, FileInfo>();
+  const getFileInfo = () => undefined as unknown as FileInfo;
+
+  beforeAll(() => {
+    useVirtualFs();
+  });
+
+  afterEach(() => {
+    getFs().reset();
+  });
+
+  function setupModule(
+    modulePath: string,
+    barrelFile: string,
+    files: string[],
+  ): Module {
+    const fs = getFs();
+    fs.createDir(modulePath);
+    for (const file of files) {
+      fs.writeFile(file, '');
+    }
+
+    return new Module(
+      toFsPath(modulePath),
+      fileInfoMap,
+      getFileInfo,
+      false,
+      true,
+      barrelFile,
+    );
+  }
+
+  it('should match the main barrel file', () => {
+    const module = setupModule('/src/app/customers', 'index.ts', [
+      '/src/app/customers/index.ts',
+    ]);
+    expect(module.isBarrelFile(toFsPath('/src/app/customers/index.ts'))).toBe(
+      true,
+    );
+  });
+
+  it('should match sub-barrel files with index.ts convention', () => {
+    const module = setupModule('/src/app/customers', 'index.ts', [
+      '/src/app/customers/index.ts',
+      '/src/app/customers/index.routing.ts',
+      '/src/app/customers/index.bookmarks.ts',
+    ]);
+    expect(
+      module.isBarrelFile(toFsPath('/src/app/customers/index.routing.ts')),
+    ).toBe(true);
+    expect(
+      module.isBarrelFile(toFsPath('/src/app/customers/index.bookmarks.ts')),
+    ).toBe(true);
+  });
+
+  it('should match sub-barrel files with custom barrel name', () => {
+    const module = setupModule('/src/app/customers', 'public-api.ts', [
+      '/src/app/customers/public-api.ts',
+      '/src/app/customers/public-api.routing.ts',
+      '/src/app/customers/public-api.bookmarks.ts',
+    ]);
+    expect(
+      module.isBarrelFile(
+        toFsPath('/src/app/customers/public-api.routing.ts'),
+      ),
+    ).toBe(true);
+    expect(
+      module.isBarrelFile(
+        toFsPath('/src/app/customers/public-api.bookmarks.ts'),
+      ),
+    ).toBe(true);
+  });
+
+  it('should not match unrelated files in the same directory', () => {
+    const module = setupModule('/src/app/customers', 'public-api.ts', [
+      '/src/app/customers/public-api.ts',
+      '/src/app/customers/customer.component.ts',
+      '/src/app/customers/other.ts',
+    ]);
+    expect(
+      module.isBarrelFile(
+        toFsPath('/src/app/customers/customer.component.ts'),
+      ),
+    ).toBe(false);
+    expect(
+      module.isBarrelFile(toFsPath('/src/app/customers/other.ts')),
+    ).toBe(false);
+  });
+
+  it('should not match files in subdirectories', () => {
+    const module = setupModule('/src/app/customers', 'public-api.ts', [
+      '/src/app/customers/public-api.ts',
+      '/src/app/customers/sub/public-api.routing.ts',
+    ]);
+    expect(
+      module.isBarrelFile(
+        toFsPath('/src/app/customers/sub/public-api.routing.ts'),
+      ),
+    ).toBe(false);
+  });
+
+  it('should not match files in parent directories', () => {
+    const module = setupModule('/src/app/customers', 'public-api.ts', [
+      '/src/app/customers/public-api.ts',
+      '/src/app/public-api.routing.ts',
+    ]);
+    expect(
+      module.isBarrelFile(toFsPath('/src/app/public-api.routing.ts')),
+    ).toBe(false);
+  });
+
+  it('should not match files with different extension', () => {
+    const module = setupModule('/src/app/customers', 'public-api.ts', [
+      '/src/app/customers/public-api.ts',
+      '/src/app/customers/public-api.routing.js',
+    ]);
+    expect(
+      module.isBarrelFile(toFsPath('/src/app/customers/public-api.routing.js')),
+    ).toBe(false);
+  });
+
+  it('should not match the barrel file name as a prefix without dot separator', () => {
+    const module = setupModule('/src/app/customers', 'public-api.ts', [
+      '/src/app/customers/public-api.ts',
+      '/src/app/customers/public-api-routing.ts',
+    ]);
+    expect(
+      module.isBarrelFile(
+        toFsPath('/src/app/customers/public-api-routing.ts'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/test-projects/angular-i/tests/expected/encapsulation-lint.json
+++ b/test-projects/angular-i/tests/expected/encapsulation-lint.json
@@ -5,7 +5,7 @@
       {
         "ruleId": "@softarc/sheriff/encapsulation",
         "severity": 2,
-        "message": "'../../data/customers-repository.service' is a deep import from a barrel module. Use the module's barrel file (index.ts) instead.",
+        "message": "'../../data/customers-repository.service' is a deep import from a barrel module. Use the module's barrel file instead.",
         "line": 4,
         "column": 1,
         "nodeType": "ImportDeclaration",

--- a/test-projects/angular-iv/tests/expected/encapsulation-lint.json
+++ b/test-projects/angular-iv/tests/expected/encapsulation-lint.json
@@ -5,7 +5,7 @@
       {
         "ruleId": "@softarc/sheriff/encapsulation",
         "severity": 2,
-        "message": "'../../data/customers-repository.service' is a deep import from a barrel module. Use the module's barrel file (index.ts) instead.",
+        "message": "'../../data/customers-repository.service' is a deep import from a barrel module. Use the module's barrel file instead.",
         "line": 4,
         "column": 1,
         "nodeType": "ImportDeclaration",


### PR DESCRIPTION
 ## Summary

This is a suggested implementation to resolve [Support multiple entry files for a single module](https://github.com/softarc-consulting/sheriff/issues/248)
 
 Adds opt-in support for **sub-barrel files** — additional module entry points that follow the naming convention `<barrelBaseName>.<suffix>.<ext>`.
 
 For example, with `barrelFileName: 'public-api.ts'`, files like `public-api.routing.ts` and `public-api.bookmarks.ts` are recognized as valid imports without triggering encapsulation violations.
 
 ## Motivation
 
 Projects using a barrel file sometimes need to split their public API into logically grouped subsets (routing, bookmarks, models, etc.) to avoid issues with [treeshaking](https://github.com/softarc-consulting/sheriff/issues/47) . This feature enables that pattern while keeping module boundaries intact.
 
 ## Changes
 
 ### Configuration
 - New optional config `enableSubBarrelFileSupport: boolean` (default `false`) — zero impact on existing users
 - Added to `UserSheriffConfig`, `Configuration`, and `defaultConfig`
 
 ### Core logic
 - **`Module.isBarrelFile(filePath)`** — new method using pure string operations (no filesystem or path API calls) to check if a file is the main barrel or a sub-barrel. Computes `barrelPrefix` and `barrelExt` once in the constructor.
 - **`accessesBarrelFileForBarrelModules`** — delegates to `module.isBarrelFile()` when the feature is enabled; falls back to the existing strict `barrelPath ===` check otherwise.
 
 ### ESLint error messages
 - Removed the hardcoded `(index.ts)` reference from the deep-import error message, since users can configure a custom `barrelFileName` — the old message would be confusing when the barrel file is e.g. `public-api.ts`
 - When `enableSubBarrelFileSupport` is enabled, the message now suggests using "the module's barrel file or a sub-barrel file"
 - When disabled, the message says "the module's barrel file" (without mentioning `index.ts`)
 
 ### Documentation
 - `configuration.md`: documented `enableSubBarrelFileSupport` option and updated `barrelFileName` description
 - `module_boundaries.md`: new "Sub-Barrel Files" section
 
 ### Tests
 - 16 unit tests for `Module.isBarrelFile()` covering: main barrel, sub-barrel with default/custom barrel names, non-barrel files, files in subdirectories, partial prefix matches, and edge cases
 - 8 integration tests for encapsulation violations with sub-barrel imports (enabled/disabled, barrel/barrel-less modules)
 - Updated existing test-project fixtures for the updated error message wording
 
 ## Commits
 
 1. `feat(core): support sub-barrel files in encapsulation checks` — config + Module.isBarrelFile + encapsulation check + ESLint message
 2. `test(core): add tests for sub-barrel file support` — unit and integration tests
 3. `test(test-projects): update encapsulation fixtures for new error message` — fixture updates for wording change
 4. `docs(docs): document sub-barrel files and enableSubBarrelFileSupport` — documentation
 
 ## Notes
 
 - Feature is behind `enableSubBarrelFileSupport: false` by default — no behavioral change for existing users
 - If enabled without barrel files (barrel-less modules), the feature is safely ignored
 - Zero new dependencies — uses only string operations
 - Sub-barrel files act only as additional entry points; module boundaries are still defined by the main barrel file