### PR TITLE
fix: address review feedback on catch-all dep rule (#246)

### DIFF
--- a/packages/core/src/lib/checks/check-for-dependency-rule-violation.ts
+++ b/packages/core/src/lib/checks/check-for-dependency-rule-violation.ts
@@ -53,11 +53,8 @@ export function checkForDependencyRuleViolation(
       );
       const isViolation = !isDependencyAllowed(
         fromTag,
-        toTags,
         config.depRules,
         {
-          from: '',
-          to: '',
           fromModulePath: fromModule,
           toModulePath: toFsPath(importedModulePath),
           fromFilePath: fsPath,

--- a/packages/core/src/lib/checks/is-dependency-allowed.ts
+++ b/packages/core/src/lib/checks/is-dependency-allowed.ts
@@ -7,7 +7,6 @@ import { NoDependencyRuleForTagError } from '../error/user-error';
 
 export const isDependencyAllowed = (
   from: string,
-  tos: string[],
   config: DependencyRulesConfig,
   context: DependencyCheckContext,
 ): boolean => {
@@ -15,7 +14,7 @@ export const isDependencyAllowed = (
   isAllowed = undefined;
   for (const tag in config) {
     if (from.match(wildcardToRegex(tag))) {
-      for (const to of tos) {
+      for (const to of context.toTags) {
         const value = config[tag];
         const matchers = Array.isArray(value) ? value : [value];
         for (const matcher of matchers) {

--- a/packages/core/src/lib/checks/tests/is-dependency-allowed.spec.ts
+++ b/packages/core/src/lib/checks/tests/is-dependency-allowed.spec.ts
@@ -16,8 +16,6 @@ const createMockDependencyCheckContext = (
   overrides?: Partial<DependencyCheckContext>,
 ): DependencyCheckContext =>
   ({
-    from: '',
-    to: '',
     fromModulePath: '',
     toModulePath: '',
     fromFilePath: '',
@@ -39,33 +37,33 @@ const dummyContext: DependencyCheckContext = createMockDependencyCheckContext({
 const createAssertsForConfig = (config: DependencyRulesConfig) => {
   return {
     assertValid(from: string, to: string | string[]) {
+      const toTags = Array.isArray(to) ? to : [to];
       expect(
         isDependencyAllowed(
           from,
-          Array.isArray(to) ? to : [to],
           config,
-          createMockDependencyCheckContext(),
+          createMockDependencyCheckContext({ toTags }),
         ),
       ).toBe(true);
     },
     assertInvalid(from: string, to: string | string[]) {
+      const toTags = Array.isArray(to) ? to : [to];
       expect(
         isDependencyAllowed(
           from,
-          Array.isArray(to) ? to : [to],
           config,
-          createMockDependencyCheckContext(),
+          createMockDependencyCheckContext({ toTags }),
         ),
       ).toBe(false);
     },
 
     assert(from: string, to: string | string[], expected: boolean) {
+      const toTags = Array.isArray(to) ? to : [to];
       expect(
         isDependencyAllowed(
           from,
-          Array.isArray(to) ? to : [to],
           config,
-          createMockDependencyCheckContext(),
+          createMockDependencyCheckContext({ toTags }),
         ),
       ).toBe(expected);
     },
@@ -119,14 +117,13 @@ describe('check dependency rules', () => {
     };
 
     expect(() =>
-      isDependencyAllowed('type:funktion', ['noop'], config, dummyContext),
+      isDependencyAllowed('type:funktion', config, dummyContext),
     ).toThrowUserError(new NoDependencyRuleForTagError('type:funktion'));
   });
 
   it('should pass from, to, fromModulePath, fromFilePath, toModulePath, toFilePath to function', () => {
     isDependencyAllowed(
       'domain:customers',
-      ['domain:holidays'],
       {
         'domain:customers': (context) => {
           expect(context).toStrictEqual({
@@ -248,7 +245,6 @@ describe('check dependency rules', () => {
       expect(
         isDependencyAllowed(
           'domain:customers',
-          ['domain:shared'],
           crossDomainConfig,
           createMockDependencyCheckContext({
             fromTags: ['domain:customers'],
@@ -262,7 +258,6 @@ describe('check dependency rules', () => {
       expect(
         isDependencyAllowed(
           'domain:customers',
-          ['domain:holidays'],
           crossDomainConfig,
           createMockDependencyCheckContext({
             fromTags: ['domain:customers'],
@@ -276,7 +271,6 @@ describe('check dependency rules', () => {
       expect(
         isDependencyAllowed(
           'type:api',
-          ['domain:holidays'],
           crossDomainConfig,
           createMockDependencyCheckContext({
             fromTags: ['type:api', 'domain:customers'],
@@ -290,7 +284,6 @@ describe('check dependency rules', () => {
       expect(
         isDependencyAllowed(
           'domain:customers',
-          ['type:api'],
           crossDomainConfig,
           createMockDependencyCheckContext({
             fromTags: ['domain:customers', 'type:feature'],
@@ -304,7 +297,6 @@ describe('check dependency rules', () => {
       expect(
         isDependencyAllowed(
           'domain:customers',
-          ['domain:customers'],
           crossDomainConfig,
           createMockDependencyCheckContext({
             fromTags: ['domain:customers'],

--- a/packages/core/src/lib/config/dependency-rules-config.ts
+++ b/packages/core/src/lib/config/dependency-rules-config.ts
@@ -1,8 +1,6 @@
 import { FsPath } from '../file-info/fs-path';
 
 export interface DependencyCheckContext {
-  from: string;
-  to: string;
   fromModulePath: FsPath;
   toModulePath: FsPath;
   fromFilePath: FsPath;
@@ -11,7 +9,9 @@ export interface DependencyCheckContext {
   toTags: string[];
 }
 
-export type RuleMatcherFn = (context: DependencyCheckContext) => boolean;
+export type RuleMatcherFn = (
+  context: { from: string; to: string } & DependencyCheckContext,
+) => boolean;
 
 export type RuleMatcher = string | null | RuleMatcherFn;
 export type DependencyRulesConfig = Record<string, RuleMatcher | RuleMatcher[]>;


### PR DESCRIPTION
Follow-up to #246 (authored by @sdurnov), which introduced `fromTags`/`toTags` support in dependency rule matcher functions.

This commit addresses the review feedback:

- Remove `from`/`to` from `DependencyCheckContext`; restore them to the `RuleMatcherFn` intersection type as they were originally
- Remove the redundant `tos` parameter from `isDependencyAllowed` — the function now iterates `context.toTags` directly, eliminating the duplicated data at every call site
- Drop the dummy `from: ''`/`to: ''` values that were needed in `checkForDependencyRuleViolation` as a result
- Update tests to match the new signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)